### PR TITLE
fix(careersystem): career screen collapses on every level-up click

### DIFF
--- a/Main/Features/CareerSystem/UI/CareerChoiceGroupObjectVM.cs
+++ b/Main/Features/CareerSystem/UI/CareerChoiceGroupObjectVM.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
@@ -9,20 +8,18 @@ namespace TAOM.Features.CareerSystem.UI;
 public class CareerChoiceGroupObjectVM : ViewModel
 {
     private readonly CareerChoiceGroupDefinition _group;
-    private readonly Action _choiceChangedAction;
     private bool _isExpanded;
     private bool _isLocked;
     private bool _isActive;
     private bool _buttonsVisible;
     private MBBindingList<CareerChoiceObjectVM> _choices;
 
-    public CareerChoiceGroupObjectVM(CareerChoiceGroupDefinition group, bool isLocked, Action choiceChangedAction = null)
+    public CareerChoiceGroupObjectVM(CareerChoiceGroupDefinition group, bool isLocked)
     {
         _group = group;
         _isLocked = isLocked;
         _isActive = !isLocked;
         _buttonsVisible = false;
-        _choiceChangedAction = choiceChangedAction;
         _choices = new MBBindingList<CareerChoiceObjectVM>();
     }
 
@@ -42,8 +39,9 @@ public class CareerChoiceGroupObjectVM : ViewModel
 
         var next = _choices.FirstOrDefault(c => !c.IsTaken);
         if (next == null) return;
+        // SelectChoice routes through the screen VM's TrySelectChoice, which already
+        // refreshes the whole screen on success; no second refresh belongs here.
         next.SelectChoice();
-        _choiceChangedAction?.Invoke();
     }
 
     public void ExecuteClickDecrease()
@@ -53,7 +51,6 @@ public class CareerChoiceGroupObjectVM : ViewModel
         var last = _choices.LastOrDefault(c => c.IsTaken);
         if (last == null) return;
         last.DeSelectChoice();
-        _choiceChangedAction?.Invoke();
     }
 
     [DataSourceProperty]

--- a/Main/Features/CareerSystem/UI/CareerScreenVM.cs
+++ b/Main/Features/CareerSystem/UI/CareerScreenVM.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
 using TAOM.Adapters;
@@ -235,6 +236,15 @@ public class CareerScreenVM : ViewModel
 
     private void RebuildChoiceGroups(CareerDefinition career)
     {
+        // Selecting or deselecting a choice refreshes the screen, which replaces every group VM.
+        // Fresh VMs start with ButtonsVisible=false and Gauntlet fires no new HoverBegin for a
+        // widget recreated under a stationary cursor, so without carrying the open state over,
+        // the +/- strip collapsed on every click.
+        var openGroupIds = new HashSet<string>();
+        CollectOpenGroupIds(_choiceGroupsTier1, openGroupIds);
+        CollectOpenGroupIds(_choiceGroupsTier2, openGroupIds);
+        CollectOpenGroupIds(_choiceGroupsTier3, openGroupIds);
+
         _choiceGroupsTier1.Clear();
         _choiceGroupsTier2.Clear();
         _choiceGroupsTier3.Clear();
@@ -245,7 +255,10 @@ public class CareerScreenVM : ViewModel
             if (group == null) continue;
 
             var isLocked = !IsTierAvail(group.Tier);
-            var groupVM = new CareerChoiceGroupObjectVM(group, isLocked, () => RefreshValues());
+            var groupVM = new CareerChoiceGroupObjectVM(group, isLocked)
+            {
+                ButtonsVisible = openGroupIds.Contains(group.Id)
+            };
 
             var choices = _registry.GetChoicesForGroup(groupId);
             foreach (var choice in choices)
@@ -261,6 +274,16 @@ public class CareerScreenVM : ViewModel
                 case 2: _choiceGroupsTier2.Add(groupVM); break;
                 case 3: _choiceGroupsTier3.Add(groupVM); break;
             }
+        }
+    }
+
+    private static void CollectOpenGroupIds(
+        MBBindingList<CareerChoiceGroupObjectVM> groups, HashSet<string> openGroupIds)
+    {
+        foreach (var groupVM in groups)
+        {
+            if (groupVM.ButtonsVisible)
+                openGroupIds.Add(groupVM.GroupId);
         }
     }
 

--- a/TAOM.Tests/Features/CareerSystem/CareerScreenVMTests.cs
+++ b/TAOM.Tests/Features/CareerSystem/CareerScreenVMTests.cs
@@ -300,6 +300,78 @@ public class CareerScreenVMTests
         Assert.AreEqual("ranger", chosenCareerId);
     }
 
+    // ── Collapse on level-up: taking or refunding a choice refreshes the screen, which rebuilds
+    // every group VM. Fresh VMs start with ButtonsVisible=false and Gauntlet fires no new
+    // HoverBegin for a widget recreated under a stationary cursor, so the +/- strip vanished on
+    // every click. Rebuilds must carry the open state over to the replacement VMs. ──
+
+    [TestMethod]
+    public void ClickIncrease_HoveredGroup_StaysOpenAfterRebuild()
+    {
+        SetupHeroWithCareer();
+        _registry.GetMaxChoicesForHero(5).Returns(10);
+        var vm = CreateVM();
+        var group = vm.ChoiceGroupsTier1[0];
+        group.ExecuteBeginHover();
+
+        group.ExecuteClickIncrease();
+
+        Assert.IsTrue(_dataService.GetOrCreateData("hero1").HasChoice("wb_brut_key"),
+            "sanity: the click should take the first untaken choice");
+        Assert.IsTrue(vm.ChoiceGroupsTier1[0].ButtonsVisible,
+            "the rebuilt group VM under the cursor should stay open");
+    }
+
+    [TestMethod]
+    public void ClickDecrease_HoveredGroup_StaysOpenAfterRebuild()
+    {
+        SetupHeroWithCareer();
+        _registry.GetMaxChoicesForHero(5).Returns(10);
+        _dataService.TryAddChoice("hero1", "wb_brut_key", 10);
+        var vm = CreateVM();
+        var group = vm.ChoiceGroupsTier1[0];
+        group.ExecuteBeginHover();
+
+        group.ExecuteClickDecrease();
+
+        Assert.IsFalse(_dataService.GetOrCreateData("hero1").HasChoice("wb_brut_key"),
+            "sanity: the click should refund the last taken choice");
+        Assert.IsTrue(vm.ChoiceGroupsTier1[0].ButtonsVisible,
+            "the rebuilt group VM under the cursor should stay open");
+    }
+
+    [TestMethod]
+    public void RefreshValues_NoGroupHovered_GroupsStayClosed()
+    {
+        SetupHeroWithCareer();
+        var vm = CreateVM();
+
+        vm.RefreshValues();
+
+        Assert.IsFalse(vm.ChoiceGroupsTier1[0].ButtonsVisible,
+            "carry-over must not open groups that were closed before the rebuild");
+    }
+
+    [TestMethod]
+    public void ClickIncrease_RebuildsGroupsOnce_NotTwice()
+    {
+        // Keystone already taken so the click lands on the passive choice -- keystone
+        // selection also scans GetChoicesForGroup for the mutual-exclusion check, which
+        // would muddy the rebuild count this test pins down.
+        SetupHeroWithCareer();
+        _registry.GetMaxChoicesForHero(5).Returns(10);
+        _dataService.TryAddChoice("hero1", "wb_brut_key", 10);
+        var vm = CreateVM();
+        _registry.ClearReceivedCalls();
+
+        vm.ChoiceGroupsTier1[0].ExecuteClickIncrease();
+
+        // One successful selection = one RefreshValues = one rebuild. The group VM's
+        // choiceChangedAction fired a second, redundant rebuild after TrySelectChoice
+        // had already refreshed the screen.
+        _registry.Received(1).GetChoicesForGroup("wb_brutality");
+    }
+
     [TestMethod]
     public void NormalMode_IsSwitchModeFalse_IsNormalModeTrue()
     {


### PR DESCRIPTION
## Problem

Clicking **+** / **−** in the career screen collapses the hovered choice group. The button strip only reappears after moving the cursor out of the panel and back in — so levelling several choices in a row means re-hovering for every single point. Reproduces on 2.0.16; reported alongside the co-op findings bundle, but this is a singleplayer bug too.

## Analysis

- The +/− strip is `IsVisible="@ButtonsVisible"`, driven purely by `Command.HoverBegin` / `Command.HoverEnd` on the group panel (`CareerScreen.xml`).
- A successful click runs `CareerChoiceObjectVM.SelectChoice` → `CareerScreenVM.TrySelectChoice` → `RefreshValues()` → `RebuildChoiceGroups()`, which discards every `CareerChoiceGroupObjectVM` and creates replacements with `ButtonsVisible = false`.
- Gauntlet fires no new `HoverBegin` for a widget recreated under a stationary cursor, so the panel closes even though the cursor never left it.
- Each click also rebuilt the tree **twice**: `ExecuteClickIncrease`/`Decrease` invoked `_choiceChangedAction` (→ `RefreshValues`) after `TrySelectChoice`/`TryDeselectChoice` had already refreshed on success.

## Solution

- `RebuildChoiceGroups` snapshots the open group ids before clearing and restores `ButtonsVisible` on the replacement VMs by `GroupId`. Closed groups stay closed; hover semantics are otherwise untouched.
- Removed the group VM's `choiceChangedAction` (field, ctor param, both invokes). The selection callbacks already refresh the screen on success, and a failed selection changes nothing worth refreshing. One click = one rebuild.

## Testing

- TDD: 4 new tests in `CareerScreenVMTests`, written first and confirmed failing on the parent commit (`ClickIncrease_HoveredGroup_StaysOpenAfterRebuild`, `ClickDecrease_HoveredGroup_StaysOpenAfterRebuild`, `ClickIncrease_RebuildsGroupsOnce_NotTwice`; the closed-stays-closed guard passed as expected), then green after the change.
- Career screen suite: 19/19 pass.
- Full suite: 4850 passed / 3 skipped / 1 failed — the failure is `OnSessionLaunched_RegistersFiefHubMenuAndOptions`, which fails identically on the clean parent commit (verified via stash), so it is unrelated to this change.

Not-tested: live Gauntlet hover behavior (unit tests can't drive the widget tree). The same carry-over-by-GroupId approach was field-verified in-game against 2.0.16 as an external `RefreshValues` postfix (multi-hour co-op sessions) before porting it here as a source fix.
