### PR TITLE
fix(tools): lint_docs reports only real rot in the version and link checks

### DIFF
--- a/tools/lint_docs.py
+++ b/tools/lint_docs.py
@@ -67,6 +67,9 @@ AGENTS_MD_WARN_BYTES = 40_000      # report-only early warning
 CHANGELOG_ARCHIVE_DIR = DOCS_DIR / "changelog-archive"
 # Gitignored raw Codex transcripts (docs/reviews/raw/): on-disk reference only, never curated.
 REVIEWS_RAW_DIR = DOCS_DIR / "reviews" / "raw"
+# Architecture Decision Records: point-in-time by definition — an ADR names the versions that were
+# current when the decision was taken, and rewriting them falsifies the record.
+ADRS_DIR = DOCS_DIR / "adrs"
 MAIN_FEATURES_DIR = REPO_ROOT / "Main" / "Features"
 
 LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
@@ -85,6 +88,10 @@ STALE_VERSION_EXEMPT_PREFIXES = (
     str(AUDITS_DIR).replace("\\", "/"),
     str(CHANGELOG_ARCHIVE_DIR).replace("\\", "/"),
     str(REVIEWS_RAW_DIR).replace("\\", "/"),
+    # The comment above already claimed "ADRs that name old versions historically" were exempt,
+    # but docs/adrs/ was never in this tuple — so adrs/010, the ADR that recorded THIS very
+    # problem, was itself reported as rot. Implementing the intent that was already documented.
+    str(ADRS_DIR).replace("\\", "/"),
 )
 DEAD_LINK_EXEMPT_PREFIXES = (
     str(ARCHIVE_DIR).replace("\\", "/"),
@@ -112,6 +119,22 @@ STALE_VERSION_EXEMPT_FILENAME_SUBSTRINGS = (
     "audit-",
 )
 STALE_VERSION_EXEMPT_DIR_PARTS = ("docs/reviews/lessons",)
+# The exemptions above are all whole-FILE switches (directory, filename, path part). That is the
+# wrong granularity and is why #397 stayed at 29 findings after the 2026-08-05 exemption sweep:
+# the remaining sites live in docs that must stay linted (native-skin-fixes.md alone holds 10),
+# and the real distinction is per LINE — "is this naming the CURRENT target, or recording history?"
+# So the model flips: a version string alone is not rot; a version string presented as current is.
+# Measured against the 29: this clears 26. The wording-marker approach from the issue clears 16.
+CURRENT_TARGET_RE = re.compile(
+    r"\b(current(ly)?|target(s|ed|ing)?|now|active|supported|"
+    r"builds? against|building against|pinned to)\b", re.I)
+# Residue after that flip: contrast lines that name an old version AND a present-tense word, where
+# the present-tense word belongs to the CURRENT version, also named on the same line — e.g.
+# "that mod ships a v1.3.15-only DLL. TAOM tracks the current engine (v1.4.7)", and the rule text
+# in agent-operating-manual.md that defines staleness. A line that states the pin is not claiming
+# an older version is the target; it is comparing the two. Resolved in the checker, so no doc is
+# edited (issue #397: "Do not 'fix' the 29 by editing the docs. They are accurate; the check is
+# wrong."). Trade-off: prose that names the pin AND wrongly calls an old version current is missed.
 # Codex review *transcripts* (prompts + results) are external-tool snapshots, not curated docs.
 # We don't lint their internal links either — they capture historical state and we don't edit them.
 DEAD_LINK_EXEMPT_FILENAME_SUBSTRINGS = (
@@ -214,6 +237,22 @@ def is_dead_link_exempt(f: Path) -> bool:
     return False
 
 
+def is_never_committed_target(p: Path) -> bool:
+    """True for link targets under docs/reviews/raw/, which is gitignored (.gitignore:157 — the
+    raw Codex transcripts are 2-4 MB each and stay on the reviewing machine).
+
+    Those files exist for whoever ran the review and for nobody else, so the same rca-*/REVIEW-LOG
+    links that resolve on the authoring machine are dead on every fresh clone — 14 of them today.
+    That asymmetry is why this check reads as clean locally while every other contributor sees it
+    dirty, and it is a property of the TARGET, not of the linking file: exempting the linking files
+    instead (they are already exempt from the stale-version check) would switch off dead-link
+    coverage for REVIEW-LOG.md's several hundred other links."""
+    try:
+        return p.is_relative_to(REVIEWS_RAW_DIR)
+    except (OSError, ValueError):
+        return False
+
+
 def looks_like_path_target(target: str) -> bool:
     """Heuristic: real path targets don't have unescaped whitespace.
     Filters out things like `[xml](Get-Content $versionXml -Raw)` (PowerShell type accelerator
@@ -239,13 +278,25 @@ def check_dead_links(files: list[Path]) -> list[tuple[Path, int, str, str]]:
                 resolved = resolve_link(f, target)
                 if resolved is None:
                     continue
+                if is_never_committed_target(resolved):
+                    continue
                 if not resolved.exists():
                     findings.append((f, lineno, target, label))
     return findings
 
 
+def _read_pin() -> str:
+    """The pinned game version, normalised and without the leading v ('1.4.7'); '' if unreadable."""
+    try:
+        return _norm_ver((REPO_ROOT / ".claude" / "pinned-game-version.txt").read_text(encoding="utf-8"))
+    except OSError:
+        return ""
+
+
 def check_stale_versions(files: list[Path]) -> list[tuple[Path, int, str, str]]:
     findings: list[tuple[Path, int, str, str]] = []
+    pin = _read_pin()
+    pin_re = re.compile(r"\bv?" + re.escape(pin) + r"\b") if pin else None
     for f in files:
         f_posix = str(f).replace("\\", "/")
         if any(f_posix.startswith(prefix) for prefix in STALE_VERSION_EXEMPT_PREFIXES):
@@ -262,6 +313,19 @@ def check_stale_versions(files: list[Path]) -> list[tuple[Path, int, str, str]]:
             for pattern, label in STALE_VERSION_PATTERNS:
                 m = pattern.search(line)
                 if m:
+                    # Rot is a present-tense claim, not a mention (#397). A line that merely
+                    # records when something happened ("ported for TAOM v1.3.15", "v1.3.15
+                    # reference RVA, informational only") is correct as written.
+                    # Test that on the line with inline code stripped: a present-tense word inside
+                    # backticks is an identifier, not a claim — `CampaignTime.Now` in an API-break
+                    # note (messengers.md:23) is the whole reason this is scrubbed. The version
+                    # match above stays on the raw line, where a `1.3.15` in backticks still counts.
+                    if not CURRENT_TARGET_RE.search(INLINE_CODE_RE.sub("", line)):
+                        break
+                    # ...and a line that also names the pin is contrasting the two, not claiming
+                    # the old one is current.
+                    if pin_re and pin_re.search(line):
+                        break
                     findings.append((f, lineno, label, line.strip()[:140]))
                     break  # one finding per line is enough
     return findings

--- a/tools/lint_docs.py
+++ b/tools/lint_docs.py
@@ -286,16 +286,19 @@ def check_dead_links(files: list[Path]) -> list[tuple[Path, int, str, str]]:
 
 
 def _read_pin() -> str:
-    """The pinned game version, normalised and without the leading v ('1.4.7'); '' if unreadable."""
+    """The pinned game version exactly as committed ('v1.4.7'); '' if absent or unreadable.
+
+    Returned raw, not normalised: check_version_consistency quotes it verbatim in its findings.
+    """
     try:
-        return _norm_ver((REPO_ROOT / ".claude" / "pinned-game-version.txt").read_text(encoding="utf-8"))
+        return (REPO_ROOT / ".claude" / "pinned-game-version.txt").read_text(encoding="utf-8").strip()
     except OSError:
         return ""
 
 
 def check_stale_versions(files: list[Path]) -> list[tuple[Path, int, str, str]]:
     findings: list[tuple[Path, int, str, str]] = []
-    pin = _read_pin()
+    pin = _norm_ver(_read_pin())
     pin_re = re.compile(r"\bv?" + re.escape(pin) + r"\b") if pin else None
     for f in files:
         f_posix = str(f).replace("\\", "/")
@@ -427,13 +430,7 @@ def _norm_ver(s: str) -> str:
 
 def check_version_consistency() -> list[tuple[Path, int, str, str]]:
     findings: list[tuple[Path, int, str, str]] = []
-    pin_file = REPO_ROOT / ".claude" / "pinned-game-version.txt"
-    if not pin_file.exists():
-        return findings
-    try:
-        pin_raw = pin_file.read_text(encoding="utf-8").strip()
-    except OSError:
-        return findings
+    pin_raw = _read_pin()
     pin = _norm_ver(pin_raw)
     if not pin:
         return findings

--- a/tools/tests/test_lint_docs.py
+++ b/tools/tests/test_lint_docs.py
@@ -160,5 +160,103 @@ class NormVerTests(unittest.TestCase):
         self.assertEqual(ld._norm_ver("1.4.7"), "1.4.7")
 
 
+class _PathConstantRepo(_TempRepo):
+    """_TempRepo + the path constants derived from DOCS_DIR at import time.
+
+    lint_docs computes ADRS_DIR / REVIEWS_RAW_DIR / the exempt prefixes once at module load,
+    so repointing DOCS_DIR alone leaves them aimed at the real repo. Repoint them too, or the
+    synthetic tree is linted against the real repo's exemptions.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._orig_consts = (ld.ADRS_DIR, ld.REVIEWS_RAW_DIR, ld.STALE_VERSION_EXEMPT_PREFIXES)
+        ld.ADRS_DIR = ld.DOCS_DIR / "adrs"
+        ld.REVIEWS_RAW_DIR = ld.DOCS_DIR / "reviews" / "raw"
+        ld.STALE_VERSION_EXEMPT_PREFIXES = (str(ld.ADRS_DIR).replace("\\", "/"),)
+
+    def tearDown(self):
+        (ld.ADRS_DIR, ld.REVIEWS_RAW_DIR, ld.STALE_VERSION_EXEMPT_PREFIXES) = self._orig_consts
+        super().tearDown()
+
+    def _doc(self, rel: str, body: str) -> Path:
+        p = self.root / "docs" / rel
+        _write(p, body)
+        return p
+
+
+class StaleVersionRotTests(_PathConstantRepo):
+    """#397: the check reported 29 findings, all historical references, and no real rot.
+
+    Its model was "a version string older than the pin is rot". The model here is "a version
+    string PRESENTED AS THE CURRENT TARGET is rot", so these tests pin both directions: real
+    rot must still fire (or the fix is indistinguishable from deleting the check), and each
+    shape of legitimate historical reference must not.
+    """
+
+    def setUp(self):
+        super().setUp()
+        _write(self.root / ".claude" / "pinned-game-version.txt", "v1.4.7\n")
+
+    def _stale(self, rel: str, body: str):
+        return ld.check_stale_versions([self._doc(rel, body)])
+
+    def test_naming_an_old_version_as_the_current_target_is_still_reported(self):
+        """The fixture #397 asks for: the check must still fire on genuine rot."""
+        found = self._stale("features/rotten.md", "The current target is Bannerlord 1.3.15.\n")
+        self.assertEqual(len(found), 1, "genuine rot must still be reported")
+        self.assertEqual(found[0][1], 1)
+
+    def test_port_note_recording_when_it_happened_is_not_reported(self):
+        # docs/features/companion-tactics.md:11 shape
+        self.assertEqual(
+            self._stale("features/port.md", "Ported from the 1.3 template for TAOM v1.3.15.\n"), [])
+
+    def test_self_labelled_historical_baseline_is_not_reported(self):
+        # docs/features/native-skin-fixes.md:123 shape — 10 of the original 29 were this file
+        self.assertEqual(
+            self._stale("features/rva.md", "| `historicalRva` | v1.3.15 reference RVA, informational only |\n"), [])
+
+    def test_line_that_also_names_the_pin_is_a_contrast_not_a_claim(self):
+        # docs/features/native-skin-fixes.md:57 shape: "current" belongs to the pin on the same line
+        self.assertEqual(
+            self._stale("features/contrast.md",
+                        "That mod ships a v1.3.15-only DLL. TAOM tracks the current engine (v1.4.7).\n"), [])
+
+    def test_present_tense_word_inside_inline_code_is_not_a_claim(self):
+        # docs/features/messengers.md:23 shape: `CampaignTime.Now` is an identifier, not "now"
+        self.assertEqual(
+            self._stale("features/api.md",
+                        "- Bannerlord 1.3.15 introduced API breaks: use `CampaignTime.Now` for elapsed math.\n"), [])
+
+    def test_adrs_are_exempt_as_point_in_time_records(self):
+        # The exemption comment already claimed ADRs were covered; the tuple never included them,
+        # so adrs/010 — the ADR that recorded this very problem — reported itself as rot.
+        self.assertEqual(
+            self._stale("adrs/010-thing.md", "Stale refs (`Bannerlord 1.3.15` when the current target is 1.4.5).\n"), [])
+
+
+class DeadLinkNeverCommittedTests(_PathConstantRepo):
+    """#397 follow-on: 14 dead links, all pointing into the gitignored docs/reviews/raw/.
+
+    Those transcripts exist only on the machine that ran the review, so the check read clean
+    for the author and dirty on every fresh clone. Exempting by TARGET keeps dead-link coverage
+    for the linking files' other links.
+    """
+
+    def test_link_into_the_gitignored_raw_dir_is_not_reported(self):
+        doc = self._doc("reviews/rca-thing.md", "See [review](raw/codex-adversarial-thing.md).\n")
+        self.assertEqual(ld.check_dead_links([doc]), [])
+
+    def test_a_genuinely_missing_target_is_still_reported(self):
+        doc = self._doc("reviews/rca-thing.md", "See [notes](../features/gone.md).\n")
+        self.assertEqual(len(ld.check_dead_links([doc])), 1, "real dead links must still be reported")
+
+    def test_an_existing_target_is_not_reported(self):
+        self._doc("features/here.md", "# here\n")
+        doc = self._doc("reviews/rca-thing.md", "See [notes](../features/here.md).\n")
+        self.assertEqual(ld.check_dead_links([doc]), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`python tools/lint_docs.py` reported 43 findings on a fresh clone and none of them
were rot: 29 stale version refs (all legitimate historical references) and 14 dead
links (all pointing into the gitignored `docs/reviews/raw/`). Both are fixed in the
checker. **No doc content is changed** — `tools/lint_docs.py` is the only source file
touched.

Closes #397.

## Stale version refs: 29 → 0

The check's model was "a version string older than the pin is rot". It is now "a
version string presented as the **current target** is rot", which is the definition
`docs/ai-includes/agent-operating-manual.md` already states. That alone clears 26 of
the 29. Three refinements resolve the rest in the checker rather than in the docs:

- The present-tense test runs on the line with **inline code stripped**. A word inside
  backticks is an identifier, not a claim — `CampaignTime.Now` in the API-break note at
  `messengers.md:23` was the only finding that survived the first pass. The version
  match itself still runs on the raw line, where a `` `1.3.15` `` in backticks counts.
- A line that **also names the pin** is contrasting the two, not calling the old one
  current — `native-skin-fixes.md:57` ("that mod ships a v1.3.15-only DLL. TAOM tracks
  the current engine (v1.4.7)") and `agent-operating-manual.md:47`, the rule text that
  defines staleness.
- **`docs/adrs/` joins the exempt prefixes.** The comment above that tuple already said
  exemptions covered "ADRs that name old versions historically", but `docs/adrs/` was
  never in it — so `adrs/010`, the ADR that recorded this very problem, reported itself
  as rot.

**Known gap, documented at the call site:** prose that names the pin *and* wrongly calls
an older version current is missed. That is the cost of resolving the contrast lines
without editing any doc.

## Dead links: 14 → 0

All 14 point into `docs/reviews/raw/`, which is gitignored (`.gitignore:157` — the raw
review transcripts are 2-4 MB each and stay on disk). Those files exist for whoever ran
the review and for nobody else, so the same links resolve on the authoring machine and
are dead on every fresh clone. The check therefore reads clean locally and dirty for
every other contributor.

Skipped **by target**, not by linking file. Exempting the linking files instead — the
`rca-*` and `REVIEW-LOG` names already exempt from the stale-version check — would
switch off dead-link coverage for `REVIEW-LOG.md`'s several hundred other links.

## Testing

```
python tools/lint_docs.py --summary     # 43 findings -> 0, git status clean
python -m unittest discover -s tools/tests -p "test_lint_docs.py"   # 23 passed
python tools/lint_docs.py --fail-on-drift ; echo $?                 # 0
```

9 tests added, `tools/tests/test_lint_docs.py`:

- **`test_naming_an_old_version_as_the_current_target_is_still_reported`** — the
  genuine-rot fixture the issue asks for. Without it this change is indistinguishable
  from deleting the check.
- One per historical shape that was misreported: port note, self-labelled baseline,
  contrast line naming the pin, present-tense word inside inline code, ADR.
- Both dead-link directions: a target under `raw/` is not reported, a genuinely missing
  target still is, an existing target is not.

Also verified end-to-end against the real tree: appending
`The current target is Bannerlord 1.3.15.` to `docs/features/messengers.md` makes the
check report exactly 1 finding, and removing it returns to 0.

Two notes from the run, unrelated to this change:
`tools/tests/test_translate_batching.py` errors on Python 3.11 —
`Path.read_text(newline=...)` needs 3.13.

## Incidental

`_read_pin()` extracted so the new gate and `check_version_consistency` read
`.claude/pinned-game-version.txt` through one place. It returns the pin verbatim
because `check_version_consistency` quotes it in its findings; that function's three
early returns collapse into the existing empty-pin guard. No behaviour change.
