### PR TITLE
fix(tools): honour BANNERLORD_GAME_DIR in the five audits that hardcode the install

### DIFF
--- a/tools/audit_battle_scenes.py
+++ b/tools/audit_battle_scenes.py
@@ -7,10 +7,16 @@ exists on disk (v1.4.5 removed/renamed it), a FIELD BATTLE on a cell with that i
 crashes. Also checks map_indices coverage 0-255 (an uncovered index = no battle scene).
 """
 from __future__ import annotations
+import os
 import re
 from pathlib import Path
 
-GAME = Path(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = Path(os.environ.get(
+    "BANNERLORD_GAME_DIR",
+    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
+))
 MODULES = GAME / "Modules"
 FILES = {
     "TAOM": MODULES / "TAOM" / "ModuleData" / "sp_battle_scenes.xml",

--- a/tools/audit_mount_parity.py
+++ b/tools/audit_mount_parity.py
@@ -23,7 +23,12 @@ from collections import OrderedDict
 
 from tpac_clipinfo import parse as parse_clip
 
-GAME = r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.path.join(os.environ.get(
+    "BANNERLORD_GAME_DIR",
+    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
+), "Modules")
 LOTR = GAME + r"\LOTRLOME_Armory\ModuleData"
 WARG = GAME + r"\Alliance.Wargs\ModuleData"
 NATIVE = GAME + r"\Native\ModuleData"

--- a/tools/audit_scene_names.py
+++ b/tools/audit_scene_names.py
@@ -13,10 +13,16 @@ Outputs:
   4. Vanilla-vs-TAOM diff (scenes TAOM uses that vanilla doesn't, and vice versa).
 """
 from __future__ import annotations
+import os
 import re
 from pathlib import Path
 
-GAME = Path(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = Path(os.environ.get(
+    "BANNERLORD_GAME_DIR",
+    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
+))
 MODULES = GAME / "Modules"
 
 SETTLEMENT_FILES = {

--- a/tools/validate_all_troop_refs.py
+++ b/tools/validate_all_troop_refs.py
@@ -16,9 +16,14 @@ import os
 import sys
 import glob
 
-ARMORY_ROOT = (
-    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
-    r"\Modules\LOTRLOME_Armory\ModuleData\LOTRLOME_items"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+ARMORY_ROOT = os.path.join(
+    os.environ.get(
+        "BANNERLORD_GAME_DIR",
+        r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
+    ),
+    "Modules", "LOTRLOME_Armory", "ModuleData", "LOTRLOME_items",
 )
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tools/validate_gondor_refs.py
+++ b/tools/validate_gondor_refs.py
@@ -14,9 +14,16 @@ TROOPS_FILE = os.path.join(
     "Main", "_Module", "ModuleData", "troops", "troops_gondor.xml"
 )
 
-ARMORY_BASE = (
-    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
-    r"\Modules\LOTRLOME_Armory\ModuleData\LOTRLOME_items\gondor"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+# (tools/.env.example also documents a narrower TAOM_ARMORY_BASE, but only
+# cleanup_deleted_gondor_items.py reads it; the game root is the consistent knob here.)
+ARMORY_BASE = os.path.join(
+    os.environ.get(
+        "BANNERLORD_GAME_DIR",
+        r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
+    ),
+    "Modules", "LOTRLOME_Armory", "ModuleData", "LOTRLOME_items", "gondor",
 )
 
 REF_RE = re.compile(r'Item\.((?:sk_gd|sk_dg)_[A-Za-z0-9_]+)')


### PR DESCRIPTION
## Summary

Five `tools/` diagnostics resolve the game install from a literal
`E:\Steam\steamapps\common\Mount & Blade II Bannerlord` and offer no CLI override, so they
cannot be run at all on any install that is not yours. Each now reads `BANNERLORD_GAME_DIR`
— the variable `README.md` already lists as a prerequisite and `setup-dev-env.ps1` already
sets — keeping the current literal as the fallback.

Closes #400.

## Change

The same two-line shape in all five, copied from `verify_mount_assets.py` rather than
invented:

```python
GAME = Path(os.environ.get(
    "BANNERLORD_GAME_DIR",
    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
))
```

| tool | before | after |
|---|---|---|
| `audit_battle_scenes.py` | literal | env, literal fallback |
| `audit_mount_parity.py` | literal | env, literal fallback |
| `audit_scene_names.py` | literal | env, literal fallback |
| `validate_all_troop_refs.py` | literal | env, literal fallback |
| `validate_gondor_refs.py` | literal | env, literal fallback |

## Testing

On a second machine (game at `D:\SteamLibrary\...`, `BANNERLORD_GAME_DIR` set), all five run
to completion where none of them previously started:

```
audit_battle_scenes.py       exit 0,  75 lines
audit_mount_parity.py        exit 0, 433 lines
audit_scene_names.py         exit 0, 251 lines
validate_all_troop_refs.py   exit 0,  12 lines
validate_gondor_refs.py      exit 0,  38 lines
```

With the variable unset they resolve to the same `E:\Steam\...` paths as before, so nothing
changes on a machine that was already working:

```
$ env -u BANNERLORD_GAME_DIR python tools/audit_battle_scenes.py
TAOM: 0 Scene ids  (E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules\TAOM\ModuleData\sp_battle_scenes.xml)
```

All five are read-only — no writes, no side effects — which I checked before running them
against a live install.

## Deliberately not included

- **The other six tools** with the same literal default (`audit_action_set_parity`,
  `audit_civilian_action_set_coverage`, `audit_siege_props`, `validate_mesh_refs`,
  `validate_moduledata`, `check_prefab_budget`). They accept a path flag so they are usable
  today, and changing their default changes behaviour for tools you run daily. Question left
  open in #400.
- **The output these tools produce.** Running them surfaces findings that have presumably not
  been looked at recently, including entries under `audit_scene_names`' CRASH SUSPECTS
  heading. I have not verified any of it — my module set is smaller than yours, so those are
  as likely to be artefacts of my install as real. Flagging that the output exists, not
  claiming anything about it.
