### PR TITLE
fix(namedcompanions): give named companions a home settlement so MapFaction resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 > **Archive:** entries before 2026-07-01 live in [`docs/changelog-archive/CHANGELOG-2026-H1.md`](docs/changelog-archive/CHANGELOG-2026-H1.md) (rolled 2026-07-12; cadence: each Jan 1 / Jul 1 — keep the current half-year here, roll the rest).
 
+## 2026-08-07
+
+### fix(namedcompanions): give named companions a home settlement so MapFaction resolves
+
+A player reported the Erebor tournament crashing over and over. Crash bundle `d7d9f7d3`
+(TAOM v2.0.18.0, Bannerlord v1.4.7.117484) is a `NullReferenceException` in
+`SandBox.ViewModelCollection.Tournament.TournamentVM.OnTournamentEnd`, reached from
+`ExecuteSkipRound` → `TournamentBehavior.SkipMatch` → `EndCurrentMatch` → the `TournamentEnd` event.
+The line is `TournamentWinner.Character.ArmorColor1 = heroObject.MapFaction.Color` — the winner's
+`MapFaction` is null.
+
+**Named companions have no map faction at all, and never have.** `Hero.MapFaction` returns null when
+`Clan`, `HomeSettlement` and `PartyBelongedTo` are all null, and all eighteen named companions hit
+every branch:
+
+- `characters/heroes.xml` gives each of them `faction="Faction.neutral"`, and `Hero.Deserialize`
+  reads the reference then does `if (clan.StringId != "neutral") this.Clan = clan;` — so `Clan`
+  stays null by design.
+- `Hero.Deserialize` never assigns `BornSettlement`; only `HeroCreator.InitializeHeroFromSettings`
+  does, via `HeroCreationModel.GetBornSettlement`. XML heroes never go through it.
+  `Hero.UpdateHomeSettlement` then falls through governor / spouse / children / parents / siblings /
+  clan / `CompanionOf` / notable and lands on `_bornSettlement` — null.
+- A companion waiting in a tavern has `StayingInSettlement`, not `PartyBelongedTo`.
+
+`NamedCompanionAdapter.PlaceInSettlement` only called `EnterSettlementAction.ApplyForCharacterOnly`,
+which sets `StayingInSettlement` and nothing else, so placement never closed the gap.
+
+**Why Erebor, and why the tournament.** `FightTournamentGame.CanNpcJoinTournament` admits
+`hero.IsLord || hero.IsWanderer`, and named companions are `occupation="Wanderer"` sitting in
+`settlement.HeroesWithoutParty`, so they enter. Their skills run 250-350, so they win. Four of the
+eighteen — Gimli, Thanor, Whitegoat and Hatérade — spawn in `town_E1`, more than any other town, so
+Erebor produced a clanless winner nearly every time. `TournamentManager.GivePrizeToWinner` guards
+this two frames earlier (`if (winner.Clan != null)`); the view model does not.
+
+`INamedCompanionAdapter.EnsureHomeSettlement` sets `BornSettlement` to the companion's configured
+spawn settlement when it is null — the same field `HeroCreator` fills for every runtime-created
+wanderer. `SpawnCompanions` calls it before placing; `EnsureCompanionsPlaced` calls it **ahead of the
+placement-state guards**, because a companion in an existing save is already placed, recruited,
+imprisoned or a fugitive and every one of those guards short-circuits. `_bornSettlement` is
+`[SaveableField(630)]`, so the repair persists and runs once per save.
+
+Not a tournament fix. The null was reachable from anything that dereferences `MapFaction` on these
+heroes; the tournament is just where it landed hardest.
+
 ## 2026-08-06
 
 ### feat(diagnostics): attribute town-gold drains and name why each caravan is parked (#391)

--- a/Main/Adapters/INamedCompanionAdapter.cs
+++ b/Main/Adapters/INamedCompanionAdapter.cs
@@ -13,6 +13,14 @@ public interface INamedCompanionAdapter
     bool IsHeroPrisoner(string characterId);
     bool IsHeroFugitive(string characterId);
 
+    // Named companions are XML heroes carrying faction="Faction.neutral", and Hero.Deserialize
+    // skips the Clan assignment for that literal id — so Clan stays null. XML deserialization never
+    // assigns BornSettlement either (only HeroCreator does), so HomeSettlement resolves to null too,
+    // and a companion sitting in a tavern has no PartyBelongedTo. All three null makes
+    // Hero.MapFaction return null, which the engine dereferences unguarded in several places.
+    // Returns true when a repair was applied.
+    bool EnsureHomeSettlement(string characterId, string settlementId);
+
     void PlaceInSettlement(string characterId, string settlementId);
     void MarkAsMet(string characterId);
 }

--- a/Main/Adapters/NamedCompanionAdapter.cs
+++ b/Main/Adapters/NamedCompanionAdapter.cs
@@ -51,6 +51,23 @@ public class NamedCompanionAdapter : INamedCompanionAdapter
         return hero.HeroState == Hero.CharacterStates.Fugitive;
     }
 
+    public bool EnsureHomeSettlement(string characterId, string settlementId)
+    {
+        var hero = Hero.AllAliveHeroes.FirstOrDefault(h => h.StringId == characterId);
+        if (hero == null || hero.BornSettlement != null) return false;
+
+        var settlement = Settlement.Find(settlementId);
+        if (settlement == null) return false;
+
+        // Hero.UpdateHomeSettlement falls all the way through to _bornSettlement for a companion
+        // with no clan, no CompanionOf and no governor relatives, so this is the field that decides
+        // whether MapFaction resolves. The setter clears the cached _homeSettlement for us. This is
+        // what HeroCreator.InitializeHeroFromSettings does for every runtime-created wanderer —
+        // XML heroes are the only ones that miss it.
+        hero.BornSettlement = settlement;
+        return true;
+    }
+
     public void PlaceInSettlement(string characterId, string settlementId)
     {
         var hero = Hero.AllAliveHeroes.FirstOrDefault(h => h.StringId == characterId);

--- a/Main/Features/NamedCompanions/NamedCompanionService.cs
+++ b/Main/Features/NamedCompanions/NamedCompanionService.cs
@@ -49,6 +49,7 @@ public class NamedCompanionService : INamedCompanionService
 
             try
             {
+                _companionAdapter.EnsureHomeSettlement(companion.CharacterId, companion.SpawnSettlement);
                 _companionAdapter.PlaceInSettlement(companion.CharacterId, companion.SpawnSettlement);
                 _companionAdapter.MarkAsMet(companion.CharacterId);
 
@@ -70,12 +71,23 @@ public class NamedCompanionService : INamedCompanionService
     public void EnsureCompanionsPlaced()
     {
         var companions = _configProvider.GetCompanions();
+        var repaired = 0;
 
         foreach (var companion in companions)
         {
             if (!companion.Enabled) continue;
             if (!_companionAdapter.HeroExists(companion.CharacterId)) continue;
             if (!_companionAdapter.IsHeroAlive(companion.CharacterId)) continue;
+
+            // Crash d7d9f7d3 — deliberately ahead of every placement-state guard below. A companion
+            // in an existing save is already in a settlement, recruited, imprisoned or on the run,
+            // so all of those short-circuit; the null BornSettlement would never be repaired if this
+            // sat with the placement call. The null is a property of the hero, not of where it is.
+            if (_companionAdapter.EnsureHomeSettlement(companion.CharacterId, companion.SpawnSettlement))
+            {
+                repaired++;
+            }
+
             if (_companionAdapter.IsRecruitedOrInParty(companion.CharacterId)) continue;
             // #127 P1 — Entity State Matrix completion. Prisoner / Fugitive companions previously
             // slipped through ALL guards (PartyBelongedTo=null, CurrentSettlement=null,
@@ -95,6 +107,12 @@ public class NamedCompanionService : INamedCompanionService
                 _logger.LogError(
                     $"[NamedCompanions] Failed to re-place '{companion.CharacterId}': {ex.Message}");
             }
+        }
+
+        if (repaired > 0)
+        {
+            _logger.LogInfo(
+                $"[NamedCompanions] Repaired a missing home settlement on {repaired} named companion(s)");
         }
     }
 

--- a/TAOM.Tests/Features/NamedCompanions/NamedCompanionServiceTests.cs
+++ b/TAOM.Tests/Features/NamedCompanions/NamedCompanionServiceTests.cs
@@ -324,6 +324,153 @@ public class NamedCompanionServiceTests
         _companionAdapter.DidNotReceive().MarkAsMet(Arg.Any<string>());
     }
 
+    // ── Null MapFaction repair (crash d7d9f7d3) ──
+    // Named companions are XML heroes with faction="Faction.neutral"; Hero.Deserialize skips the
+    // Clan assignment for that id, and XML deserialization never sets BornSettlement. Clan +
+    // HomeSettlement + PartyBelongedTo all null makes Hero.MapFaction return null, and the engine
+    // dereferences it unguarded — TournamentVM.OnTournamentEnd reads MapFaction.Color on the winner,
+    // so any Erebor tournament won by one of the four companions living in town_E1 took the game
+    // down. Repair runs before the placement-state guards so already-placed companions in existing
+    // saves are fixed too, not just freshly placed ones.
+
+    [TestMethod]
+    public void SpawnCompanions_EnabledCompanion_RepairsHomeSettlementBeforePlacing()
+    {
+        SetupCompanions(new NamedCompanionDefinition
+        {
+            CharacterId = "nc_a",
+            SpawnSettlement = "town_1",
+            Race = "dwarf",
+            Enabled = true
+        });
+        _companionAdapter.HeroExists("nc_a").Returns(true);
+        _raceManager.GetRaceIdFromName("dwarf").Returns(1);
+
+        _sut.SpawnCompanions();
+
+        Received.InOrder(() =>
+        {
+            _companionAdapter.EnsureHomeSettlement("nc_a", "town_1");
+            _companionAdapter.PlaceInSettlement("nc_a", "town_1");
+        });
+    }
+
+    [TestMethod]
+    public void EnsureCompanionsPlaced_AlreadyPlaced_StillRepairsHomeSettlement()
+    {
+        // The load-path regression that matters: an existing save has the companion already sitting
+        // in the tavern, so every placement guard short-circuits. The repair must run anyway.
+        SetupCompanions(new NamedCompanionDefinition
+        {
+            CharacterId = "nc_gimli",
+            SpawnSettlement = "town_E1",
+            Race = "dwarf",
+            Enabled = true
+        });
+        _companionAdapter.HeroExists("nc_gimli").Returns(true);
+        _companionAdapter.IsHeroAlive("nc_gimli").Returns(true);
+        _companionAdapter.IsPlacedInSettlement("nc_gimli").Returns(true);
+
+        _sut.EnsureCompanionsPlaced();
+
+        _companionAdapter.Received(1).EnsureHomeSettlement("nc_gimli", "town_E1");
+        _companionAdapter.DidNotReceive().PlaceInSettlement(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [TestMethod]
+    public void EnsureCompanionsPlaced_RecruitedCompanion_StillRepairsHomeSettlement()
+    {
+        SetupCompanions(new NamedCompanionDefinition
+        {
+            CharacterId = "nc_a",
+            SpawnSettlement = "town_1",
+            Race = "human",
+            Enabled = true
+        });
+        _companionAdapter.HeroExists("nc_a").Returns(true);
+        _companionAdapter.IsHeroAlive("nc_a").Returns(true);
+        _companionAdapter.IsRecruitedOrInParty("nc_a").Returns(true);
+
+        _sut.EnsureCompanionsPlaced();
+
+        _companionAdapter.Received(1).EnsureHomeSettlement("nc_a", "town_1");
+    }
+
+    [TestMethod]
+    public void EnsureCompanionsPlaced_DeadHero_DoesNotRepairHomeSettlement()
+    {
+        SetupCompanions(new NamedCompanionDefinition
+        {
+            CharacterId = "nc_a",
+            SpawnSettlement = "town_1",
+            Race = "human",
+            Enabled = true
+        });
+        _companionAdapter.HeroExists("nc_a").Returns(true);
+        _companionAdapter.IsHeroAlive("nc_a").Returns(false);
+
+        _sut.EnsureCompanionsPlaced();
+
+        _companionAdapter.DidNotReceive().EnsureHomeSettlement(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [TestMethod]
+    public void EnsureCompanionsPlaced_DisabledCompanion_DoesNotRepairHomeSettlement()
+    {
+        SetupCompanions(new NamedCompanionDefinition
+        {
+            CharacterId = "nc_a",
+            SpawnSettlement = "town_1",
+            Race = "human",
+            Enabled = false
+        });
+
+        _sut.EnsureCompanionsPlaced();
+
+        _companionAdapter.DidNotReceive().EnsureHomeSettlement(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [TestMethod]
+    public void EnsureCompanionsPlaced_RepairsApplied_LogsCount()
+    {
+        SetupCompanions(
+            new NamedCompanionDefinition { CharacterId = "nc_a", SpawnSettlement = "town_E1", Race = "dwarf", Enabled = true },
+            new NamedCompanionDefinition { CharacterId = "nc_b", SpawnSettlement = "town_E1", Race = "dwarf", Enabled = true }
+        );
+        foreach (var id in new[] { "nc_a", "nc_b" })
+        {
+            _companionAdapter.HeroExists(id).Returns(true);
+            _companionAdapter.IsHeroAlive(id).Returns(true);
+            _companionAdapter.IsPlacedInSettlement(id).Returns(true);
+        }
+        _companionAdapter.EnsureHomeSettlement("nc_a", "town_E1").Returns(true);
+        _companionAdapter.EnsureHomeSettlement("nc_b", "town_E1").Returns(false);
+
+        _sut.EnsureCompanionsPlaced();
+
+        _logger.Received(1).LogInfo(Arg.Is<string>(s => s.Contains("home settlement") && s.Contains("1")));
+    }
+
+    [TestMethod]
+    public void EnsureCompanionsPlaced_NoRepairsNeeded_LogsNothing()
+    {
+        SetupCompanions(new NamedCompanionDefinition
+        {
+            CharacterId = "nc_a",
+            SpawnSettlement = "town_1",
+            Race = "human",
+            Enabled = true
+        });
+        _companionAdapter.HeroExists("nc_a").Returns(true);
+        _companionAdapter.IsHeroAlive("nc_a").Returns(true);
+        _companionAdapter.IsPlacedInSettlement("nc_a").Returns(true);
+        _companionAdapter.EnsureHomeSettlement("nc_a", "town_1").Returns(false);
+
+        _sut.EnsureCompanionsPlaced();
+
+        _logger.DidNotReceive().LogInfo(Arg.Any<string>());
+    }
+
     [TestMethod]
     public void ResetSession_AllowsSpawnCompanionsAgainInSameProcess()
     {


### PR DESCRIPTION
A player reported the Erebor tournament crashing over and over. The crash bundle is a
`NullReferenceException` with a one-line cause, but the null belongs to the named companions, not to
the tournament — the tournament is just the loudest place it surfaces.

## The crash

Bundle `d7d9f7d3`, TAOM v2.0.18.0 on Bannerlord v1.4.7.117484, save in `town_E1` "Erebor":

```
System.NullReferenceException
  at SandBox.ViewModelCollection.Tournament.TournamentVM.OnTournamentEnd()
  at SandBox.Tournaments.MissionLogics.TournamentBehavior.EndCurrentMatch(Boolean isLeave)
  at SandBox.ViewModelCollection.Tournament.TournamentVM.ExecuteSkipRound()
```

`OnTournamentEnd` (SandBox.ViewModelCollection, v1.4.7):

```csharp
Hero heroObject = TournamentWinner.Participant.Character.HeroObject;
TournamentWinner.Character.ArmorColor1 = heroObject.MapFaction.Color;   // ← null
```

## Why MapFaction is null

`Hero.MapFaction` returns null when `Clan`, `HomeSettlement` and `PartyBelongedTo` are all null. All
eighteen named companions hit every branch:

| Field | Why it's null |
|---|---|
| `Clan` | `characters/heroes.xml` gives each companion `faction="Faction.neutral"`, and `Hero.Deserialize` reads the reference then does `if (clan.StringId != "neutral") this.Clan = clan;` — the assignment is skipped by design. |
| `HomeSettlement` | `Hero.Deserialize` never assigns `BornSettlement`; only `HeroCreator.InitializeHeroFromSettings` does, via `HeroCreationModel.GetBornSettlement`, and XML heroes never go through it. `Hero.UpdateHomeSettlement` falls through governor → spouse → children → parents → siblings → clan → `CompanionOf` → notable and lands on `_bornSettlement`. |
| `PartyBelongedTo` | A companion waiting in a tavern has `StayingInSettlement`, not a party. |

`NamedCompanionAdapter.PlaceInSettlement` only called `EnterSettlementAction.ApplyForCharacterOnly`,
which sets `StayingInSettlement` and nothing else — so placement never closed the gap.

Vanilla never trips over this because every vanilla wanderer is built by `HeroCreator`, which always
assigns a born settlement.

## Why Erebor specifically

`FightTournamentGame.CanNpcJoinTournament` admits `hero.IsLord || hero.IsWanderer`. Named companions
are `occupation="Wanderer"` sitting in `settlement.HeroesWithoutParty`, so they enter. Their skills
run 250–350, so they win. And `named_companion_config.json` puts **four** of the eighteen in
`town_E1` — Gimli, Thanor, Whitegoat, Hatérade — more than any other town, so Erebor produced a
clanless winner nearly every time.

Worth noting the campaign side already guards this two frames earlier —
`TournamentManager.GivePrizeToWinner` does `if (winner.Clan != null)`. The view model does not.

## The change

`INamedCompanionAdapter.EnsureHomeSettlement` sets `BornSettlement` to the companion's configured
spawn settlement when it is null — the same field `HeroCreator` fills for every runtime-created
wanderer. `Hero`'s setter clears the cached `_homeSettlement` for us.

- `SpawnCompanions` calls it before placing (new games).
- `EnsureCompanionsPlaced` calls it **ahead of the placement-state guards** (existing saves). This
  ordering is the load-bearing part: a companion in an existing save is already placed, recruited,
  imprisoned or a fugitive, and every one of those guards `continue`s. Sitting the repair next to
  the placement call would fix new games only.

`_bornSettlement` is `[SaveableField(630)]`, so the repair persists and runs once per save.

Deliberately **not** a tournament patch. The null was reachable from anything dereferencing
`MapFaction` on these heroes; the tournament is where it hurt.

## Tests

RED → GREEN, seven new tests in `NamedCompanionServiceTests`:

- `SpawnCompanions_EnabledCompanion_RepairsHomeSettlementBeforePlacing` (`Received.InOrder`)
- `EnsureCompanionsPlaced_AlreadyPlaced_StillRepairsHomeSettlement` ← the existing-save regression
- `EnsureCompanionsPlaced_RecruitedCompanion_StillRepairsHomeSettlement`
- `EnsureCompanionsPlaced_DeadHero_DoesNotRepairHomeSettlement`
- `EnsureCompanionsPlaced_DisabledCompanion_DoesNotRepairHomeSettlement`
- `EnsureCompanionsPlaced_RepairsApplied_LogsCount`
- `EnsureCompanionsPlaced_NoRepairsNeeded_LogsNothing`

RED run with the service wiring reverted: **4 failed, 19 passed** in the class (the three
`DidNotReceive` tests pass trivially without the wiring, as they should).

Full suite, `dotnet build TAOM.sln -c Release` (0 errors) then `dotnet test TAOM.Tests -c Release`:

| | Total | Passed | Failed | Skipped |
|---|---|---|---|---|
| Baseline (`612e72ea`, clean) | 5688 | 5683 | 2 | 3 |
| This branch | 5695 | 5690 | 2 | 3 |

The same two fail before and after — `OnSessionLaunched_RegistersFiefHubMenuAndOptions` and
`Wave1Feats_ProductionMetadata_MatchesSpec`. Both read repo source files through a relative path walk
and threw `DirectoryNotFoundException` for `C:\Users\theje\Main\Features\...` because I ran them from
a git worktree outside the usual repo location. Pre-existing and environmental, not touched by this
change — but worth a look separately, since they'd fail on any non-standard checkout path.

Built against the installed v1.4.7 DLLs (`BANNERLORD_GAME_DIR`). Note that CI's **Build & Test job is
skipped** on this repo — it is gated on `vars.BANNERLORD_GAME_DIR != ''` and that repository variable
is unset, so every green run so far has only validated XML/XSLT/JSON. The numbers above are local.

## Verification left to do

The adapter path itself is not unit-testable — it touches `Hero` and `Settlement` directly. In-game
check: load an Erebor save, confirm
`[NamedCompanions] Repaired a missing home settlement on N named companion(s)` appears once, then
enter a tournament, get eliminated, and press **Skip** through to the end.

**Player workaround until this ships:** press **Leave**, not **Skip**. `EndTournamentViaLeave` passes
`isLeave: true`, and `EndCurrentMatch` only fires the `TournamentEnd` event when `!isLeave` — so the
view model callback never runs. Confirmed in the same log: the player left at 18:30 and the mission
ended cleanly; they skipped at 19:27 and it crashed.

## Follow-up worth considering

A finalizer swallowing only `NullReferenceException` on `TournamentVM.OnTournamentEnd` would harden
against any future clanless winner from another data source. Left out here on purpose — the data fix
is the root cause, and a guard would leave the end-of-tournament panel half-built.
