### PR TITLE
fix(dwarf): point the female dwarf underwear slot at the mesh that ships

### DIFF
--- a/docs/reference/lotrlome-armory-snapshot/skins.xml
+++ b/docs/reference/lotrlome-armory-snapshot/skins.xml
@@ -1777,7 +1777,7 @@
 			legs_mesh="sk_dwarf_bm_f1_legs"
 			hands_mesh="sk_dwarf_bm_f1_arms"
 			face_meta_mesh="sk_dwarf_bm_f1_head"
-			underwear_bottom_mesh="sk_dwarf_underwear_female"
+			underwear_bottom_mesh="sk_dwarf_underwear_female_a"
 			underwear_top_mesh="">
 			<deform_keys>
 				<deform_key


### PR DESCRIPTION
**Draft — the change is unverified in-game, and this file alone ships nothing. Please do not merge until someone confirms the repro.**

## What players hit

> "every instance that I attempt to find a female dwarf in a settlement/battle/tournament, if my camera looks at them it crashes my game, but it will not crash if I interact with them in dialogue"

Native access violation, no managed exception, so no crash report is produced:

```
ExceptionCode : 0xC0000005  READ
Parameter-1   : 0x24C (588)              <- faulting address
Address       : TaleWorlds.Native.dll +0x58232C
```

Disassembled from a minidump of the same fault:

```asm
movzx edx, word [r8 + r9*2]     ; r8 = 0 (null), r9 = 294  ->  0 + 294*2 = 0x24C
```

A 16-bit index array read at a null base — a triangle index buffer, i.e. geometry that failed to resolve. The same fault appears in four separate native crash folders from one reporter and in a minidump from a second, unrelated reporter.

## The defect

`skins.xml`, adult female dwarf skin:

```xml
<race id="dwarf">
  <skin gender="1" name="woman" skeleton="dwarf_skeleton_a"
        underwear_bottom_mesh="sk_dwarf_underwear_female" />
```

That resource does not exist. The asset packages ship **`sk_dwarf_underwear_female_a`** — 8 occurrences. The bare name appears only as a prefix of the `_a` variant, never as a complete resource name (checked as `…female"` and `…female\0`, both absent).

Two things make it fit the report:

- Across all 12 races and ~140 skin entries in this file, it is the **only** underwear reference that does not resolve to a shipped mesh.
- The adult female dwarf is the **only** dwarf skin with a non-empty `underwear_bottom_mesh` — males and every dwarf child entry are `""`. So it touches female dwarves and nothing else.

## Why the observed pattern matches

Underwear renders only when clothing leaves the slot visible, which explains what the logs show:

| observation | |
|---|---|
| Flási renders fine as `as_dwarf_female_warrior`, crashes as `as_dwarf_female_lord` | same character — the outfit is the variable, not the individual |
| 4 of 5 crashes in `sturgia_castle_keep_a_*_interior` | keeps are where civilians and nobles stand in civilian dress |
| every arena and conversation scene clean | armour, and the facegen/portrait path |
| dialogue safe | conversation uses `as_dwarf_female_facegen`, which TableauDiag logs as resolving valid |

## Scope — this PR does not fix anyone's game

`docs/reference/lotrlome-armory-snapshot/README.md` is explicit that these files are **"Not registered or loaded by TAOM. Storage only."** The shipped file lives in `LOTRLOME_Armory/ModuleData/skins.xml`.

Per that README's stated purpose — preserving edits applied to LOTRLOME's working copy — the operative steps are:

1. apply the same one attribute in `Modules/LOTRLOME_Armory/ModuleData/skins.xml` in the install,
2. confirm the repro is gone (walk into an Erebor keep interior),
3. then merge this so a LOTRLOME update cannot silently revert it,
4. and ideally upstream it to LOTRLOME.

Ordering matters: the README describes the snapshot as mirroring an edit that has **already** been applied and verified. This PR arrives before that, deliberately, so the evidence has somewhere to live — hence draft.

## Verification status

- Verified: the string is absent from every asset package; `_a` is present; it is the only unresolved underwear reference in the file; the XML still parses; the diff is one attribute.
- **Not** verified: that the engine faults on this specific unresolved reference. That is inference from the fault shape plus the behavioural pattern. One restart with the install-side edit settles it.
- Read against `bannerlord-1.4.5` (this repo). Reporters are on TAOM v2.0.18.0 / Bannerlord v1.4.7.117484; the snapshot carries the same defect, so it is not a version artefact.

## Separately

`orc_rider_sword_02_*` and `orc_rider_sword_03_*` (blade/grip/guard/pommel, 8 meshes) are referenced by Alliance.Wargs and present in no asset package. Different module, not addressed here.

An earlier pass of mine flagged `sk_dwarf_erebor_pauldron _scale_*` and `legolas gloves` as broken. **Those were false positives** — the meshes genuinely contain spaces in their names and exist verbatim. Do not "fix" the spaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
