### PR TITLE
fix(tools): stale-version check — the phrasings rot uses, and 1.4.5/1.4.6

### DIFF
--- a/docs/features/native-skin-fixes.md
+++ b/docs/features/native-skin-fixes.md
@@ -122,7 +122,7 @@ The six byte patterns scanned at boot. Each entry has:
 | `byteOffsetFromMatch` | `int` | Usually `0`. Non-zero when the pattern anchors a unique caller and we offset to the callee. |
 | `historicalRva` | `long long` | v1.3.15 reference RVA, informational only (helps IDA navigation when re-authoring) |
 
-### Current values (Bannerlord v1.4.6 — authored 2026-06-30)
+### Shipped values (authored 2026-06-30 against Bannerlord v1.4.6)
 
 All 7 signatures are authored + statically verified against the installed v1.4.6
 `TaleWorlds.Native.dll` (each is a single match at the RVA below). See the

--- a/docs/reference/worldmap-battle-scene-grid.md
+++ b/docs/reference/worldmap-battle-scene-grid.md
@@ -22,7 +22,7 @@ Middle-earth map**. Companion to [scene-reference-audit.md](scene-reference-audi
 > also wrong (over-inferred from a crash). The grid is **not** baked into `Main_map`/`terrain.bin`; it is a
 > runtime `Assets/world_map/` texture. The authoritative source is
 > [BannerlordModding.LT › Battle Scene Grid](https://docs.bannerlordmodding.lt/editor/battle_scene_grid/) (1.2.12,
-> now confirmed to still apply on 1.4.5).
+> confirmed to still apply as of 1.4.5).
 
 > ## ⚠️ A mis-imported grid CRASHES campaign load
 >

--- a/tools/lint_docs.py
+++ b/tools/lint_docs.py
@@ -125,9 +125,20 @@ STALE_VERSION_EXEMPT_DIR_PARTS = ("docs/reviews/lessons",)
 # and the real distinction is per LINE — "is this naming the CURRENT target, or recording history?"
 # So the model flips: a version string alone is not rot; a version string presented as current is.
 # Measured against the 29: this clears 26. The wording-marker approach from the issue clears 16.
+# The marker set IS the detection surface, so rot phrased outside it is silent (#405). Widened with
+# four verb phrases and the bare `Engine:` label — all of them name a current target without using a
+# marker word. Measured on the real tree: still 0 findings, so this buys detection at no
+# false-positive cost, which is why it lands now rather than behind an exemption pass.
+# `Engine\s*:` sits OUTSIDE the \b group deliberately: a word boundary after a colon needs a word
+# character next, so `Engine: 1.3.15` can never match from inside it.
 CURRENT_TARGET_RE = re.compile(
     r"\b(current(ly)?|target(s|ed|ing)?|now|active|supported|"
-    r"builds? against|building against|pinned to)\b", re.I)
+    r"builds? against|building against|pinned to|"
+    r"built for|requires?|compatible with)\b"
+    # `runs on` is ordinary technical English — doc-health-linter.md:69 says a regex "still runs on
+    # the raw line" — so it only counts as a target claim when a version follows it.
+    r"|\bruns? on\s+(?:Bannerlord\b|v?\d)"
+    r"|\bEngine\s*:", re.I)
 # Residue after that flip: contrast lines that name an old version AND a present-tense word, where
 # the present-tense word belongs to the CURRENT version, also named on the same line — e.g.
 # "that mod ships a v1.3.15-only DLL. TAOM tracks the current engine (v1.4.7)", and the rule text

--- a/tools/lint_docs.py
+++ b/tools/lint_docs.py
@@ -78,6 +78,24 @@ STALE_VERSION_PATTERNS = [
     (re.compile(r"\bv?1\.3\.15\b"), "1.3.15"),
     (re.compile(r"\bBannerlord\s+1\.3\b(?!\.)"), "Bannerlord 1.3"),
     (re.compile(r"\bv1\.3\.x\b"), "v1.3.x"),
+    # agent-operating-manual.md names v1.4.5 and v1.4.6 stale alongside v1.3.15; the checker
+    # never looked for them, so the rule and its enforcement disagreed (#405 gap 2).
+    #
+    # `(?<![-\w.])` keeps the branch name out. The active branch IS `bannerlord-1.4.5`, quoted 53
+    # times across 21 docs — "the active branch (currently `bannerlord-1.4.5`)" in
+    # TRANSLATOR_GUIDE.md:229 is correct, current prose that a bare \b pattern reads as rot, and no
+    # wording rule can tell the two apart because the sentence genuinely says "currently".
+    # `(?<![-\w.])` covers two distinct hyphen cases, both real in this tree:
+    #   - the branch name. The active branch IS `bannerlord-1.4.5`, quoted 53 times across 21
+    #     docs; TRANSLATOR_GUIDE.md:229 — "the active branch (currently `bannerlord-1.4.5`)" — is
+    #     correct, current prose that no wording rule can separate from a claim.
+    #   - hyphenated compound modifiers. spider.md:262 heads a dated section "(2026-06-12,
+    #     post-1.4.6 campaign)"; "post-1.4.6" describes when the campaign ran.
+    # Narrowing this to `(?<!bannerlord-)` was tried and re-admitted spider.md:262, so the broad
+    # form stays. The cost is disclosed: a claim spelled with a hyphen before the digits is not
+    # seen. `test_a_current_claim_about_145_is_reported` pins that the ordinary spelling still is.
+    (re.compile(r"(?<![-\w.])v?1\.4\.5\b"), "1.4.5"),
+    (re.compile(r"(?<![-\w.])v?1\.4\.6\b"), "1.4.6"),
 ]
 # Paths where v1.3 refs are intentional (migration docs, archived material, ADRs that name old versions historically).
 # docs/audits/ is the v1.3.15 migration audit record — every "v1.3.15-unverified" flag and
@@ -117,6 +135,12 @@ STALE_VERSION_EXEMPT_FILENAME_SUBSTRINGS = (
     # rca-*; the lessons/ dir quotes old versions as the historical context of each lesson.
     "REVIEW-LOG",
     "audit-",
+    # The docs that DESCRIBE this checker have to quote rot to explain it: doc-health-linter.md
+    # lists the shapes it catches, doc-lookup.md summarises the marker set. Same self-reference
+    # as agent-operating-manual.md — the rule text that defines staleness reads as stale — and
+    # the same reason `doc-lint-` is already here.
+    "doc-health-linter",
+    "doc-lookup",
 )
 STALE_VERSION_EXEMPT_DIR_PARTS = ("docs/reviews/lessons",)
 # The exemptions above are all whole-FILE switches (directory, filename, path part). That is the
@@ -131,14 +155,39 @@ STALE_VERSION_EXEMPT_DIR_PARTS = ("docs/reviews/lessons",)
 # false-positive cost, which is why it lands now rather than behind an exemption pass.
 # `Engine\s*:` sits OUTSIDE the \b group deliberately: a word boundary after a colon needs a word
 # character next, so `Engine: 1.3.15` can never match from inside it.
+# How far from the version string a marker still counts as describing it. See the call site in
+# check_stale_versions for the measurement this number comes from.
+MARKER_WINDOW = 60
 CURRENT_TARGET_RE = re.compile(
-    r"\b(current(ly)?|target(s|ed|ing)?|now|active|supported|"
+    r"\b(current(ly)?|now|supported|"
     r"builds? against|building against|pinned to|"
     r"built for|requires?|compatible with)\b"
-    # `runs on` is ordinary technical English — doc-health-linter.md:69 says a regex "still runs on
-    # the raw line" — so it only counts as a target claim when a version follows it.
+    # `target` carries two senses and only one is a claim. "hook targets remain authored",
+    # "All 7 targets were re-derived", "Patch targets exist in v1.4.5" are NOUNS — the thing a
+    # patch points at — and they sit next to a version in exactly the docs that discuss porting.
+    # The claim sense is either the label form (`Target: Bannerlord X`, the CLAUDE.md header this
+    # check exists to catch) or the verb followed by a version.
+    r"|\bTargets?\s*:"
+    r"|\btarget(s|ed|ing)?\s+(?:Bannerlord\b|v?\d)"
+    # …and the copula form. "Our target version IS 1.3.15", "the active version IS 1.3.15",
+    # "our target REMAINS 1.3.15" are claims the pre-#405 checker caught with a bare marker;
+    # narrowing to "marker immediately before a version" dropped them. What separates them from
+    # the noun senses is that a version follows the verb: "hook targets REMAIN authored" and
+    # "All 7 targets WERE re-derived" do not.
+    r"|\b(?:target|active)\w*\s+(?:\w+\s+){0,2}(?:is|are|was|were|remains?)\s+"
+    r"(?:the\s+|Bannerlord\s+)*v?\d"
+    # Same two senses: `runs on` is ordinary technical English — doc-health-linter.md:69 says a
+    # regex "still runs on the raw line".
     r"|\bruns? on\s+(?:Bannerlord\b|v?\d)"
-    r"|\bEngine\s*:", re.I)
+    # `active` has the same noun/adjective split as `target`: "423 missing active action types"
+    # (lotrlome-armory-snapshot/README.md:99) is a category of animation, not a claim about an
+    # engine version. Only the version-facing sense counts.
+    r"|\bactive\s+(?:Bannerlord\b|v?\d)"
+    # Reverse order: "Bannerlord 1.3.15 is the active engine."
+    r"|\bv?[\d.]+\s+is\s+(?:the\s+)?(?:active|current|target)\b"
+    # `Engine:` as a LABEL — line start, table cell, bullet or heading. Mid-sentence it is just
+    # punctuation: elephant.md:309 says "verified against the engine: `Vec2.LeftVec()` …".
+    r"|(?:^|[|>#*-]\s*)Engine\s*:", re.I | re.M)
 # Residue after that flip: contrast lines that name an old version AND a present-tense word, where
 # the present-tense word belongs to the CURRENT version, also named on the same line — e.g.
 # "that mod ships a v1.3.15-only DLL. TAOM tracks the current engine (v1.4.7)", and the rule text
@@ -307,6 +356,39 @@ def _read_pin() -> str:
         return ""
 
 
+CLAUSE_BREAK_RE = re.compile(
+    r"(?<=[.!?])\s"          # sentence end
+    r"|\s\|\s|\|"            # table cell
+    r"|\(see\b",             # cross-reference aside: "(see \"v1.4.6 native port\")" names a
+                             # section, it does not claim a target
+    re.I)
+# A version the sentence explicitly rules OUT is not a claim that it is current:
+# elephant.md:117 says the donor pack is "built for Bannerlord ~1.2.12, NOT 1.4.5".
+NEGATED_VERSION_RE = re.compile(r"\b(not|never|isn't|is not|rather than|instead of)\s*$", re.I)
+
+
+def clause_around(line: str, match: re.Match) -> str:
+    """The clause the version sits in: same sentence, same table cell, bounded by MARKER_WINDOW.
+
+    A markdown line is a whole paragraph — castle-recruitment.md:117 runs 1,450 characters — so
+    "a marker somewhere on this line" pairs words that have nothing to do with each other. Two
+    bounds, and both are needed:
+
+    - **Clause.** castle-recruitment.md:117 reads "… returning null on v1.4.6). Current dev data
+      has full coverage" — "Current" opens a new sentence about the DATA. Splitting on sentence
+      ends and table-cell pipes keeps a marker with the version it actually describes.
+    - **Distance.** A clause can still be long; MARKER_WINDOW caps how far the search reaches.
+      Measured over the 1.4.5/1.4.6 candidates, real pairs sit within ~51 characters and the
+      nearest unrelated one was at 71, so the cap sits in that gap.
+    """
+    lo = max(0, match.start() - MARKER_WINDOW)
+    hi = min(len(line), match.end() + MARKER_WINDOW)
+    for b in CLAUSE_BREAK_RE.finditer(line, lo, match.start()):
+        lo = b.end()                       # last break before the version wins
+    right = CLAUSE_BREAK_RE.search(line, match.end(), hi)
+    return line[lo:right.start() if right else hi]
+
+
 def check_stale_versions(files: list[Path]) -> list[tuple[Path, int, str, str]]:
     findings: list[tuple[Path, int, str, str]] = []
     pin = _norm_ver(_read_pin())
@@ -334,7 +416,17 @@ def check_stale_versions(files: list[Path]) -> list[tuple[Path, int, str, str]]:
                     # backticks is an identifier, not a claim — `CampaignTime.Now` in an API-break
                     # note (messengers.md:23) is the whole reason this is scrubbed. The version
                     # match above stays on the raw line, where a `1.3.15` in backticks still counts.
-                    if not CURRENT_TARGET_RE.search(INLINE_CODE_RE.sub("", line)):
+                    #
+                    # The marker must also be NEAR the version. A markdown line here is a whole
+                    # paragraph — castle-recruitment.md:117 runs 1,450 characters — so "somewhere on
+                    # the same line" pairs a marker with a version that has nothing to do with it.
+                    # Measured over the 1.4.5/1.4.6 candidate set: 11 findings have the marker within
+                    # 51 characters of the version, the next is at 71, and the tail reaches 1,228.
+                    # The window sits in that gap. Widening it re-admits paragraph noise; narrowing
+                    # it starts dropping ordinary prose like "TAOM is built for Bannerlord 1.3.15."
+                    if NEGATED_VERSION_RE.search(line[max(0, m.start() - 24):m.start()]):
+                        break
+                    if not CURRENT_TARGET_RE.search(INLINE_CODE_RE.sub("", clause_around(line, m))):
                         break
                     # ...and a line that also names the pin is contrasting the two, not claiming
                     # the old one is current.

--- a/tools/tests/test_lint_docs.py
+++ b/tools/tests/test_lint_docs.py
@@ -261,6 +261,96 @@ class StaleVersionRotTests(_PathConstantRepo):
         self.assertEqual(
             len(self._stale("features/e.md", "Engine: 1.3.15\n")), 1)
 
+    # --- #405 gap 2: 1.4.5 / 1.4.6, and the shapes that made them noisy -----------------------
+    # agent-operating-manual.md names both stale alongside 1.3.15, but the patterns never looked
+    # for them. They are one and two steps back rather than five, so they appear all over ordinary
+    # prose — 24 raw hits, of which 22 were noise. Each test below pins one reason a hit was noise.
+
+    def test_a_current_claim_about_145_is_reported(self):
+        self.assertEqual(len(self._stale("features/v1.md", "The current target is Bannerlord 1.4.5.\n")), 1)
+
+    def test_a_current_claim_about_146_is_reported(self):
+        self.assertEqual(len(self._stale("features/v2.md", "TAOM currently builds against v1.4.6.\n")), 1)
+
+    def test_the_branch_name_is_not_a_version_claim(self):
+        # The active branch IS `bannerlord-1.4.5`, quoted 53 times across 21 docs. This sentence is
+        # correct, current prose and says "currently" — no wording rule could separate the two.
+        self.assertEqual(
+            self._stale("localization/g.md",
+                        "Open a PR targeting the active branch (currently `bannerlord-1.4.5`).\n"), [])
+
+    def test_a_hyphenated_compound_is_not_a_version_claim(self):
+        # spider.md:262 — "(2026-06-12, post-1.4.6 campaign)" says WHEN the campaign ran.
+        self.assertEqual(
+            self._stale("features/hy.md",
+                        "## Current state & known issues (2026-06-12, post-1.4.6 campaign)\n"), [])
+
+    # The claim/silence pairs below exist because a guard that only ever has a negative test can
+    # be over-broad without anything noticing. Each silence above has a firing counterpart.
+
+    def test_the_copula_form_of_target_is_still_a_claim(self):
+        # Caught by the pre-#405 checker with a bare marker; narrowing to "marker immediately
+        # before a version" dropped it, which is a worse defect than the noise it removed.
+        for line in ("The target is Bannerlord 1.3.15.\n",
+                     "Our target version is 1.3.15.\n",
+                     "Our target remains 1.3.15.\n"):
+            self.assertEqual(len(self._stale(f"features/c{hash(line) & 0xffff}.md", line)), 1, line)
+
+    def test_the_copula_form_of_active_is_still_a_claim(self):
+        for line in ("The active version is 1.3.15.\n",
+                     "Bannerlord 1.3.15 is the active engine.\n"):
+            self.assertEqual(len(self._stale(f"features/a{hash(line) & 0xffff}.md", line)), 1, line)
+
+    def test_a_marker_in_a_different_sentence_does_not_pair(self):
+        # castle-recruitment.md:117 shape — "Current" opens a new sentence, about the data.
+        self.assertEqual(
+            self._stale("features/two.md",
+                        "The engine throws rather than returning null on v1.4.6. "
+                        "Current dev data has full coverage.\n"), [])
+
+    def test_a_marker_in_a_different_table_cell_does_not_pair(self):
+        self.assertEqual(
+            self._stale("features/tbl.md",
+                        "| Patch targets exist in v1.4.5 | the current pin is elsewhere |\n"), [])
+
+    def test_a_cross_reference_aside_is_not_a_claim(self):
+        # native-skin-fixes.md:322 — `(see "v1.4.6 native port")` names a section.
+        self.assertEqual(
+            self._stale("features/see.md",
+                        'The fastest path is now `tools/x.py` (see "v1.4.6 native port" below).\n'), [])
+
+    def test_an_explicitly_negated_version_is_not_a_claim(self):
+        # elephant.md:117 — "built for Bannerlord ~1.2.12, NOT 1.4.5".
+        self.assertEqual(
+            self._stale("features/neg.md",
+                        "The upstream pack is built for Bannerlord ~1.2.12, NOT 1.4.5.\n"), [])
+
+    def test_target_as_a_noun_is_not_a_claim(self):
+        # "hook targets", "patch targets" — the thing a patch points at, next to a version in
+        # exactly the docs that discuss porting.
+        self.assertEqual(
+            self._stale("features/noun.md", "The v1.4.6 hook targets remain authored + verified.\n"), [])
+
+    def test_target_as_a_verb_before_a_version_is_a_claim(self):
+        self.assertEqual(len(self._stale("features/verb.md", "TAOM targets Bannerlord 1.4.5.\n")), 1)
+
+    def test_target_as_a_label_is_a_claim(self):
+        # The CLAUDE.md header shape — the highest-value site this check exists for.
+        self.assertEqual(len(self._stale("features/lbl.md", "> **Target: Bannerlord 1.4.6**\n")), 1)
+
+    def test_active_as_an_adjective_is_not_a_claim(self):
+        # lotrlome-armory-snapshot/README.md:99 — "423 missing active action types".
+        self.assertEqual(
+            self._stale("features/adj.md",
+                        "By Native 1.4.6 it had drifted to 423 missing active action types.\n"), [])
+
+    def test_engine_label_counts_but_engine_mid_sentence_does_not(self):
+        self.assertEqual(len(self._stale("features/lab.md", "Engine: 1.4.6\n")), 1)
+        # elephant.md:309 — "verified against the engine:" is punctuation, not a label.
+        self.assertEqual(
+            self._stale("features/mid.md",
+                        "Bearing verified against the engine: `Vec2.LeftVec()` in the v1.4.5 decompile.\n"), [])
+
     def test_widening_did_not_swallow_the_historical_shapes(self):
         # The four shapes #399 exists to keep quiet must stay quiet after the widening.
         for name, line in [

--- a/tools/tests/test_lint_docs.py
+++ b/tools/tests/test_lint_docs.py
@@ -235,6 +235,42 @@ class StaleVersionRotTests(_PathConstantRepo):
         self.assertEqual(
             self._stale("adrs/010-thing.md", "Stale refs (`Bannerlord 1.3.15` when the current target is 1.4.5).\n"), [])
 
+    # --- #405 gap 1: rot phrased without a marker word --------------------------------------
+    # Each of these named a current target and was silent before the marker set was widened.
+    # One test per shape, so a later narrowing of the regex says WHICH phrasing it gave up.
+
+    def test_built_for_is_a_current_target_claim(self):
+        self.assertEqual(
+            len(self._stale("features/a.md", "TAOM is built for Bannerlord 1.3.15.\n")), 1)
+
+    def test_requires_is_a_current_target_claim(self):
+        self.assertEqual(
+            len(self._stale("features/b.md", "This feature requires Bannerlord 1.3.15.\n")), 1)
+
+    def test_runs_on_is_a_current_target_claim(self):
+        self.assertEqual(
+            len(self._stale("features/c.md", "TAOM runs on Bannerlord 1.3.15.\n")), 1)
+
+    def test_compatible_with_is_a_current_target_claim(self):
+        self.assertEqual(
+            len(self._stale("features/d.md", "Compatible with Bannerlord 1.3.15.\n")), 1)
+
+    def test_bare_engine_label_is_a_current_target_claim(self):
+        # `Engine\s*:` has to live outside the \b group — a word boundary after a colon needs a
+        # following word character, so this shape is silently missed if it is written inside it.
+        self.assertEqual(
+            len(self._stale("features/e.md", "Engine: 1.3.15\n")), 1)
+
+    def test_widening_did_not_swallow_the_historical_shapes(self):
+        # The four shapes #399 exists to keep quiet must stay quiet after the widening.
+        for name, line in [
+            ("features/h1.md", "Ported from the 1.3 template for TAOM v1.3.15.\n"),
+            ("features/h2.md", "| `historicalRva` | v1.3.15 reference RVA, informational only |\n"),
+            ("features/h3.md", "Pinned v1.3.15 ilspycmd outputs live in docs/scene-scripts/sigs/.\n"),
+            ("features/h4.md", "- Bannerlord 1.3.15 introduced API breaks: use `CampaignTime.Now`.\n"),
+        ]:
+            self.assertEqual(self._stale(name, line), [], f"{line.strip()!r} should stay silent")
+
 
 class DeadLinkNeverCommittedTests(_PathConstantRepo):
     """#397 follow-on: 14 dead links, all pointing into the gitignored docs/reviews/raw/.


### PR DESCRIPTION
## Summary

Both gaps in #405, as two commits. `lint_docs --summary` is back to `total_findings: 0`, the suite
is 44 green, and the genuine-rot fixture the issue asks to protect is present and passing.

Closes #405.

**Read the scope note before the detail — this is more than the issue asked for, deliberately, and
you should decide whether you want it.**

---

## Scope note

The issue's literal ask is "widen `CURRENT_TARGET_RE` with four verb phrases plus a bare `Engine:`
label" and "add 1.4.5/1.4.6 to `STALE_VERSION_PATTERNS`, resolve the findings". Commit 1 is exactly
that. Commit 2 is not: reaching 0 findings with 1.4.5/1.4.6 tracked needed six guards on the
matching model, none of which the issue names.

The reason is structural rather than a triage backlog. 1.3.15 is five steps behind the pin and
nobody writes it except deliberately. 1.4.5 and 1.4.6 are one and two steps behind, they appear all
over ordinary prose, and 1.4.5 is also the name of the branch — quoted 53 times across 21 docs.
Raw, the addition reports **24 findings** (the issue says 21) and **22 of the 24 are noise**.

If you would rather have the literal change and triage the 24 yourself, say so and I will cut
commit 2 back — but the result is 22 false positives against 2 true ones, which is the ratio #397
existed to fix.

---

## Two measurements that differ from the issue

**"Costs zero new findings" holds only with one adjustment.** Adding `runs? on` as a bare marker
puts the tree at 1, not 0: `docs/features/doc-health-linter.md:69` says a regex "still **runs on**
the raw line" — ordinary technical English next to a `1.3.15` example. It is gated on a version
following it, and then the tree is 0.

**`Engine:` does not work written inside the `\b(...)\b` group.** A word boundary after a colon
needs a following word character, so `Engine: 1.3.15` never matches from in there — the shape looks
covered and stays silent. It sits outside the group, and as a label (line start, table cell,
bullet) rather than mid-sentence: `elephant.md:309` reads "verified against the engine:
`Vec2.LeftVec()`".

---

## Commit 1 — the phrasings

Reproduced the issue's table against `1e2281c`: 3 of 12 shapes caught, 1 correctly silent, 8
missed. After the widening: 8 caught, 3 deliberately silent (the historical "Ported … for TAOM
v1.3.15", and the pin-contrast row the issue says to leave).

**Two shapes from the issue's own table are still missed, and are not covered by the proposed
markers:** `We are on Bannerlord v1.3.15.` and `Decompile against Bannerlord 1.3.15 before
editing.` The second is the harder one — the regex already carries `builds? against`, but widening
to a bare `against` also matches "verified against v1.3.15", which is exactly the historical shape
#399 exists to keep quiet. Left for you to decide rather than guessed at.

## Commit 2 — 1.4.5 / 1.4.6

| guard | the line it exists for |
|---|---|
| hyphen-prefixed spellings excluded from the version match | the branch name (`TRANSLATOR_GUIDE.md:229`, "the active branch (currently `bannerlord-1.4.5`)") and hyphenated compounds (`spider.md:262`, "(2026-06-12, post-1.4.6 campaign)") |
| marker must share the clause | `castle-recruitment.md:117` — "…null on v1.4.6. **Current** dev data has full coverage" opens a new sentence, about the data. That line is 1,450 characters; "somewhere on the same line" pairs words that have nothing to do with each other |
| table-cell boundary is a clause break | `REVIEW-PLAN.md:97` pairs a marker in one cell with a version in another |
| `(see …` is a cross-reference | `native-skin-fixes.md:322` — `(see "v1.4.6 native port")` names a section |
| an explicitly negated version is not a claim | `elephant.md:117` — "built for Bannerlord ~1.2.12, **NOT** 1.4.5" |
| `target` / `active` only in their claim senses | "hook targets remain", "All 7 targets were re-derived", "423 missing **active** action types" are nouns and adjectives, and they sit beside a version in exactly the docs that discuss porting |

**The last guard is where this nearly went wrong, so it is worth your attention.** Restricting
`target`/`active` to "marker immediately before a version" also dropped the copula phrasing the
merged checker catches with its bare marker — `The target is Bannerlord 1.3.15`, `Our target
version is 1.3.15`, `The active version is 1.3.15`, `Bannerlord 1.3.15 is the active engine`. That
is a worse defect than the noise it removes, because a check that stops reporting says nothing
about having stopped. Both senses are kept now: a version after the verb is a claim, a verb with no
version after it ("targets remain authored") is a noun. Four tests pin the copula forms.

**Two real findings, fixed in the docs.** Both were ambiguous to a human reader before the linter
looked at them, and neither edit rewrites a fact:

- `native-skin-fixes.md:125` — "### Current values (Bannerlord v1.4.6 — authored 2026-06-30)" reads
  as though v1.4.6 were the target. It is provenance; the body says the signatures were authored
  and verified against the installed v1.4.6. Now "Shipped values (authored 2026-06-30 against
  Bannerlord v1.4.6)".
- `worldmap-battle-scene-grid.md:25` — "now confirmed to still apply on 1.4.5" reads as a present
  claim about a pin two steps old. It is a dated confirmation: "confirmed to still apply **as of**
  1.4.5".

**Known cost, stated rather than left to be discovered:** a claim spelled with a hyphen before the
digits (`…-1.4.5`) is not seen. Narrowing the guard to just `(?<!bannerlord-)` was tried and
re-admitted `spider.md:262`, so the broad form stays.

## Testing

```
python tools/lint_docs.py --summary                                   # 0 findings
python -m unittest discover -s tools/tests -p "test_lint_docs.py"     # 44 passed
python tools/lint_docs.py --fail-on-drift ; echo $?                   # 0
```

Green on 3.11 and 3.14. Full `tools/tests` suite: 408 tests, the only 3 errors are pre-existing and
unrelated — `test_translate_batching` uses `Path.read_text(newline=…)`, which needs 3.13.

15 tests added, held against a 35-case matrix of every shape that must fire and every shape that
must stay silent, run after each change so a fix for one could not silently break another.

Two disciplines behind those numbers, because the counts alone do not show them:

- **Every negative test was verified by removing its guard.** A test asserting silence proves
  nothing if the silence was already there — guard on 0 findings, guard off 1, for all six.
- **Every silence has a firing counterpart.** The `target`/`active` regression above is exactly
  what one-sided coverage hides, so noun-vs-claim, label-vs-mid-sentence and branch-vs-version each
  ship as a pair.
