### PR TITLE
fix(cultures): lord and rebellion hero templates follow the culture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 > **Archive:** entries before 2026-07-01 live in [`docs/changelog-archive/CHANGELOG-2026-H1.md`](docs/changelog-archive/CHANGELOG-2026-H1.md) (rolled 2026-07-12; cadence: each Jan 1 / Jul 1 — keep the current half-year here, roll the rest).
 
+## 2026-08-08
+
+### fix(cultures): every culture's lord templates were Dunlendings
+
+A player granted a fief to a dwarf companion in Ered Luin and got a clan called Firebeard —
+correctly Erebor — whose two new members were named Graldor and Dunric. Both names come out of
+`taom_xslt_strings.xml`: `aom_dunland_male_name_29` and `aom_dunland_male_name_2`.
+
+All fourteen of TAOM's own cultures shipped the vanilla `empire` block verbatim for
+`<lord_templates>` **and** `<rebellion_hero_templates>` — the same sixteen
+`spc_legion_of_the_betrayed` / `spc_hidden_hand` / `spc_embers_of_flame` / `spc_eleftheroi`
+leaders, every one of them `culture="Culture.empire"` in `SandBox/ModuleData/spspecialcharacters.xml`.
+`spcultures.xslt` renames empire to the Dunlendings, so those two lists resolved to Dunlendings
+for Erebor, Rivendell, Gondor, Mordor and everywhere else. `notable_templates` had been done
+properly per culture; these two were missed.
+
+The engine never gets a second chance to correct it. `HeroCreator.CreateSpecialHero` leaves
+`Culture` unset, so `InitializeHeroFromSettings` falls through to
+`DefaultHeroCreationModel.GetCulture`, which returns
+`hero.CharacterObject.OriginalCharacter.Culture` — the template's culture. The born settlement is
+passed in and ignored. Whatever the template is, the hero is.
+
+Two code paths read the lists, and both are player-visible:
+
+- `CompanionRolesCampaignBehavior.SpawnNewHeroesForNewCompanionClan` builds two lords from
+  `companionHero.Culture.LordTemplates` every time a companion is granted a fief.
+- `RebellionsCampaignBehavior` builds rebel leaders from `settlement.Culture.RebelliousHeroTemplates`,
+  so a rising in a dwarf or Gondorian town was led by Dunlendings too.
+
+Each culture now has `spc_<culture>_lord_1` and `spc_<culture>_lord_2` in its own
+`characters/npcs_<culture>.xml`, carrying the culture's race and `BodyProperty.fighter_<culture>`
+face template, split by trait profile the way the headman templates are — bold versus cautious.
+The equipment was already written: `equipmentsets/taom_lord_template_equipment.xml` has held
+`taom_<culture>_lord_battle_male` and `_civilian_male` for all twenty cultures, reachable until now
+only through the engine's culture-and-flag search for child and coming-of-age equipment. The new
+templates reference those rosters directly.
+
+`CultureLordTemplateTests` pins the invariant: every template a culture lists must be defined by
+TAOM and carry that culture, and neither list may be empty — `MBReadOnlyList.GetRandomElement`
+indexes straight into the list and throws on an empty one. Landless cultures are exempt; neither
+code path reaches them.
+
+Heroes already in a save keep the culture they were built with. This changes what spawns from here
+on, not what has spawned.
+
 ## 2026-08-07
 
 ### fix(troopweight): shed-on-upgrade was deleting every settlement's militia down to ~20

--- a/Main/_Module/ModuleData/characters/npcs_abanissa.xml
+++ b/Main/_Module/ModuleData/characters/npcs_abanissa.xml
@@ -418,4 +418,24 @@
     </Equipments>
   </NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_abanissa_lord_* rosters. -->
+	<NPCCharacter id="spc_abanissa_lord_1" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.abanissa" name="{=aom_abanissa_lord_1}Bold Abanissa chieftain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_haradrim" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_abanissa_lord_battle_male" />
+			<EquipmentSet id="taom_abanissa_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_abanissa_lord_2" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.abanissa" name="{=aom_abanissa_lord_2}Cautious Abanissa chieftain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_haradrim" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_abanissa_lord_battle_male" />
+			<EquipmentSet id="taom_abanissa_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_dolguldur.xml
+++ b/Main/_Module/ModuleData/characters/npcs_dolguldur.xml
@@ -1403,4 +1403,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_dolguldur_lord_* rosters. -->
+	<NPCCharacter id="spc_dolguldur_lord_1" race="dg_uruk" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.dolguldur" name="{=aom_dolguldur_lord_1}Bold Dol Guldur captain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_dolguldur" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_dolguldur_lord_battle_male" />
+			<EquipmentSet id="taom_dolguldur_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_dolguldur_lord_2" race="dg_uruk" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.dolguldur" name="{=aom_dolguldur_lord_2}Cautious Dol Guldur captain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_dolguldur" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_dolguldur_lord_battle_male" />
+			<EquipmentSet id="taom_dolguldur_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_erebor.xml
+++ b/Main/_Module/ModuleData/characters/npcs_erebor.xml
@@ -1202,4 +1202,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_erebor_lord_* rosters. -->
+	<NPCCharacter id="spc_erebor_lord_1" race="dwarf" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.erebor" name="{=aom_erebor_lord_1}Bold dwarven lord" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_erebor" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_erebor_lord_battle_male" />
+			<EquipmentSet id="taom_erebor_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_erebor_lord_2" race="dwarf" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.erebor" name="{=aom_erebor_lord_2}Cautious dwarven lord" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_erebor" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_erebor_lord_battle_male" />
+			<EquipmentSet id="taom_erebor_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_goblin.xml
+++ b/Main/_Module/ModuleData/characters/npcs_goblin.xml
@@ -1258,4 +1258,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_goblin_lord_* rosters. -->
+	<NPCCharacter id="spc_goblin_lord_1" race="goblin" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.goblin" name="{=aom_goblin_lord_1}Bold goblin chieftain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_gundabad" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_goblin_lord_battle_male" />
+			<EquipmentSet id="taom_goblin_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_goblin_lord_2" race="goblin" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.goblin" name="{=aom_goblin_lord_2}Cautious goblin chieftain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_gundabad" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_goblin_lord_battle_male" />
+			<EquipmentSet id="taom_goblin_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_gondor.xml
+++ b/Main/_Module/ModuleData/characters/npcs_gondor.xml
@@ -1224,4 +1224,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_gondor_lord_* rosters. -->
+	<NPCCharacter id="spc_gondor_lord_1" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.gondor" name="{=aom_gondor_lord_1}Bold Gondorian lord" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_gondor" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_gondor_lord_battle_male" />
+			<EquipmentSet id="taom_gondor_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_gondor_lord_2" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.gondor" name="{=aom_gondor_lord_2}Cautious Gondorian lord" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_gondor" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_gondor_lord_battle_male" />
+			<EquipmentSet id="taom_gondor_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_gundabad.xml
+++ b/Main/_Module/ModuleData/characters/npcs_gundabad.xml
@@ -1258,4 +1258,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_gundabad_lord_* rosters. -->
+	<NPCCharacter id="spc_gundabad_lord_1" race="pale_uruk" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.gundabad" name="{=aom_gundabad_lord_1}Bold Gundabad captain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_gundabad" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_gundabad_lord_battle_male" />
+			<EquipmentSet id="taom_gundabad_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_gundabad_lord_2" race="pale_uruk" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.gundabad" name="{=aom_gundabad_lord_2}Cautious Gundabad captain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_gundabad" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_gundabad_lord_battle_male" />
+			<EquipmentSet id="taom_gundabad_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_isengard.xml
+++ b/Main/_Module/ModuleData/characters/npcs_isengard.xml
@@ -1730,4 +1730,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_isengard_lord_* rosters. -->
+	<NPCCharacter id="spc_isengard_lord_1" race="uruk_hai" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.isengard" name="{=aom_isengard_lord_1}Bold Uruk-hai captain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_empire" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_isengard_lord_battle_male" />
+			<EquipmentSet id="taom_isengard_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_isengard_lord_2" race="uruk_hai" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.isengard" name="{=aom_isengard_lord_2}Cautious Uruk-hai captain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_empire" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_isengard_lord_battle_male" />
+			<EquipmentSet id="taom_isengard_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_lothlorien.xml
+++ b/Main/_Module/ModuleData/characters/npcs_lothlorien.xml
@@ -430,4 +430,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_lothlorien_lord_* rosters. -->
+	<NPCCharacter id="spc_lothlorien_lord_1" race="elf" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.lothlorien" name="{=aom_lothlorien_lord_1}Bold elven lord of Lothlorien" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_rivendell" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_lothlorien_lord_battle_male" />
+			<EquipmentSet id="taom_lothlorien_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_lothlorien_lord_2" race="elf" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.lothlorien" name="{=aom_lothlorien_lord_2}Cautious elven lord of Lothlorien" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_rivendell" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_lothlorien_lord_battle_male" />
+			<EquipmentSet id="taom_lothlorien_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_mirkwood.xml
+++ b/Main/_Module/ModuleData/characters/npcs_mirkwood.xml
@@ -1121,4 +1121,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_mirkwood_lord_* rosters. -->
+	<NPCCharacter id="spc_mirkwood_lord_1" race="elf" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.mirkwood" name="{=aom_mirkwood_lord_1}Bold elven lord of Mirkwood" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_mirkwood" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_mirkwood_lord_battle_male" />
+			<EquipmentSet id="taom_mirkwood_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_mirkwood_lord_2" race="elf" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.mirkwood" name="{=aom_mirkwood_lord_2}Cautious elven lord of Mirkwood" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_mirkwood" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_mirkwood_lord_battle_male" />
+			<EquipmentSet id="taom_mirkwood_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_mistymountainorcs.xml
+++ b/Main/_Module/ModuleData/characters/npcs_mistymountainorcs.xml
@@ -1258,4 +1258,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_mistymountainorcs_lord_* rosters. -->
+	<NPCCharacter id="spc_mistymountainorcs_lord_1" race="orc" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.mistymountainorcs" name="{=aom_mistymountainorcs_lord_1}Bold Misty Mountain captain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_gundabad" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_mistymountainorcs_lord_battle_male" />
+			<EquipmentSet id="taom_mistymountainorcs_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_mistymountainorcs_lord_2" race="orc" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.mistymountainorcs" name="{=aom_mistymountainorcs_lord_2}Cautious Misty Mountain captain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_gundabad" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_mistymountainorcs_lord_battle_male" />
+			<EquipmentSet id="taom_mistymountainorcs_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_mordor.xml
+++ b/Main/_Module/ModuleData/characters/npcs_mordor.xml
@@ -1488,4 +1488,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_mordor_lord_* rosters. -->
+	<NPCCharacter id="spc_mordor_lord_1" race="uruk" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.mordor" name="{=aom_mordor_lord_1}Bold Mordor captain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_uruk_mordor" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_mordor_lord_battle_male" />
+			<EquipmentSet id="taom_mordor_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_mordor_lord_2" race="uruk" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.mordor" name="{=aom_mordor_lord_2}Cautious Mordor captain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_uruk_mordor" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_mordor_lord_battle_male" />
+			<EquipmentSet id="taom_mordor_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_rivendell.xml
+++ b/Main/_Module/ModuleData/characters/npcs_rivendell.xml
@@ -1155,4 +1155,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_rivendell_lord_* rosters. -->
+	<NPCCharacter id="spc_rivendell_lord_1" race="elf" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.rivendell" name="{=aom_rivendell_lord_1}Bold elven lord of Imladris" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_rivendell" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_rivendell_lord_battle_male" />
+			<EquipmentSet id="taom_rivendell_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_rivendell_lord_2" race="elf" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.rivendell" name="{=aom_rivendell_lord_2}Cautious elven lord of Imladris" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_rivendell" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_rivendell_lord_battle_male" />
+			<EquipmentSet id="taom_rivendell_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_shaghana.xml
+++ b/Main/_Module/ModuleData/characters/npcs_shaghana.xml
@@ -418,4 +418,24 @@
     </Equipments>
   </NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_shaghana_lord_* rosters. -->
+	<NPCCharacter id="spc_shaghana_lord_1" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.shaghana" name="{=aom_shaghana_lord_1}Bold Shaghana chieftain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_haradrim" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_shaghana_lord_battle_male" />
+			<EquipmentSet id="taom_shaghana_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_shaghana_lord_2" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.shaghana" name="{=aom_shaghana_lord_2}Cautious Shaghana chieftain" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_haradrim" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_shaghana_lord_battle_male" />
+			<EquipmentSet id="taom_shaghana_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/characters/npcs_umbar.xml
+++ b/Main/_Module/ModuleData/characters/npcs_umbar.xml
@@ -409,4 +409,24 @@
 		</Equipments>
 	</NPCCharacter>
 
+	<!-- Lord templates. Referenced from taom_spcultures.xml <lord_templates> and
+	     <rebellion_hero_templates>; both lists previously held vanilla's Culture.empire
+	     leaders, and a hero keeps its TEMPLATE's culture. Equipment comes from the
+	     already-authored taom_umbar_lord_* rosters. -->
+	<NPCCharacter id="spc_umbar_lord_1" default_group="Infantry" is_template="true" is_hero="false" voice="curt" culture="Culture.umbar" name="{=aom_umbar_lord_1}Bold corsair lord of Umbar" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_gondor" /></face>
+		<Traits><Trait id="Valor" value="1" /><Trait id="Calculating" value="-1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_umbar_lord_battle_male" />
+			<EquipmentSet id="taom_umbar_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
+	<NPCCharacter id="spc_umbar_lord_2" default_group="Infantry" is_template="true" is_hero="false" voice="earnest" culture="Culture.umbar" name="{=aom_umbar_lord_2}Cautious corsair lord of Umbar" skill_template="SkillSet.infantry_heavyinfantry_level1_template_skills" occupation="Lord">
+		<face><face_key_template value="BodyProperty.fighter_gondor" /></face>
+		<Traits><Trait id="Valor" value="-1" /><Trait id="Calculating" value="1" /></Traits>
+		<Equipments>
+			<EquipmentSet id="taom_umbar_lord_battle_male" />
+			<EquipmentSet id="taom_umbar_lord_civilian_male" equipmentType="Civilian" />
+		</Equipments>
+	</NPCCharacter>
 </NPCCharacters>

--- a/Main/_Module/ModuleData/taom_spcultures.xml
+++ b/Main/_Module/ModuleData/taom_spcultures.xml
@@ -310,40 +310,12 @@
       <template name="NPCCharacter.spc_erebor_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_erebor_lord_1" />
+      <template name="NPCCharacter.spc_erebor_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_erebor_lord_1" />
+      <template name="NPCCharacter.spc_erebor_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />
@@ -678,40 +650,12 @@
       <template name="NPCCharacter.spc_rivendell_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_rivendell_lord_1" />
+      <template name="NPCCharacter.spc_rivendell_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_rivendell_lord_1" />
+      <template name="NPCCharacter.spc_rivendell_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />
@@ -1037,40 +981,12 @@
       <template name="NPCCharacter.spc_mirkwood_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_mirkwood_lord_1" />
+      <template name="NPCCharacter.spc_mirkwood_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_mirkwood_lord_1" />
+      <template name="NPCCharacter.spc_mirkwood_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />
@@ -1397,40 +1313,12 @@
       <template name="NPCCharacter.spc_lothlorien_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_lothlorien_lord_1" />
+      <template name="NPCCharacter.spc_lothlorien_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_lothlorien_lord_1" />
+      <template name="NPCCharacter.spc_lothlorien_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />
@@ -1772,40 +1660,12 @@
       <template name="NPCCharacter.spc_isengard_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_isengard_lord_1" />
+      <template name="NPCCharacter.spc_isengard_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_isengard_lord_1" />
+      <template name="NPCCharacter.spc_isengard_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />
@@ -2138,40 +1998,12 @@
       <template name="NPCCharacter.spc_gundabad_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_gundabad_lord_1" />
+      <template name="NPCCharacter.spc_gundabad_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_gundabad_lord_1" />
+      <template name="NPCCharacter.spc_gundabad_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />
@@ -2499,40 +2331,12 @@
       <template name="NPCCharacter.spc_umbar_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_umbar_lord_1" />
+      <template name="NPCCharacter.spc_umbar_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_umbar_lord_1" />
+      <template name="NPCCharacter.spc_umbar_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />
@@ -2872,40 +2676,12 @@
       <template name="NPCCharacter.spc_dolguldur_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_dolguldur_lord_1" />
+      <template name="NPCCharacter.spc_dolguldur_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_dolguldur_lord_1" />
+      <template name="NPCCharacter.spc_dolguldur_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />
@@ -3240,40 +3016,12 @@
       <template name="NPCCharacter.spc_gondor_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_gondor_lord_1" />
+      <template name="NPCCharacter.spc_gondor_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_gondor_lord_1" />
+      <template name="NPCCharacter.spc_gondor_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />
@@ -3618,40 +3366,12 @@
       <template name="NPCCharacter.spc_mordor_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_mordor_lord_1" />
+      <template name="NPCCharacter.spc_mordor_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_mordor_lord_1" />
+      <template name="NPCCharacter.spc_mordor_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />
@@ -3907,18 +3627,12 @@
       <template name="NPCCharacter.spc_shaghana_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
+      <template name="NPCCharacter.spc_shaghana_lord_1" />
+      <template name="NPCCharacter.spc_shaghana_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
+      <template name="NPCCharacter.spc_shaghana_lord_1" />
+      <template name="NPCCharacter.spc_shaghana_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_aserai_one_participant_set_v1" />
@@ -4168,18 +3882,12 @@
       <template name="NPCCharacter.spc_abanissa_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
+      <template name="NPCCharacter.spc_abanissa_lord_1" />
+      <template name="NPCCharacter.spc_abanissa_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
+      <template name="NPCCharacter.spc_abanissa_lord_1" />
+      <template name="NPCCharacter.spc_abanissa_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_aserai_one_participant_set_v1" />
@@ -4854,40 +4562,12 @@
       <template name="NPCCharacter.spc_goblin_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_goblin_lord_1" />
+      <template name="NPCCharacter.spc_goblin_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_goblin_lord_1" />
+      <template name="NPCCharacter.spc_goblin_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />
@@ -5214,40 +4894,12 @@
       <template name="NPCCharacter.spc_mistymountainorcs_headman_3" />
     </notable_templates>
     <lord_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_mistymountainorcs_lord_1" />
+      <template name="NPCCharacter.spc_mistymountainorcs_lord_2" />
     </lord_templates>
     <rebellion_hero_templates>
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_0" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_1" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_2" />
-      <template name="NPCCharacter.spc_legion_of_the_betrayed_leader_3" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_0" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_1" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_2" />
-      <template name="NPCCharacter.spc_hidden_hand_leader_3" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_0" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_1" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_2" />
-      <template name="NPCCharacter.spc_embers_of_flame_leader_3" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_0" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_1" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_2" />
-      <template name="NPCCharacter.spc_eleftheroi_leader_3" />
+      <template name="NPCCharacter.spc_mistymountainorcs_lord_1" />
+      <template name="NPCCharacter.spc_mistymountainorcs_lord_2" />
     </rebellion_hero_templates>
     <tournament_team_templates_one_participant>
       <template name="NPCCharacter.tournament_template_empire_one_participant_set_v1" />

--- a/TAOM.Tests/Core/CultureLordTemplateTests.cs
+++ b/TAOM.Tests/Core/CultureLordTemplateTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TAOM.Tests.Core;
+
+/// <summary>
+/// Config validation tests for the per-culture hero template lists in
+/// taom_spcultures.xml.
+///
+/// Root cause these pin: every TAOM culture shipped the vanilla <c>empire</c>
+/// block verbatim for both &lt;lord_templates&gt; and
+/// &lt;rebellion_hero_templates&gt; — the sixteen
+/// <c>spc_legion_of_the_betrayed / hidden_hand / embers_of_flame / eleftheroi</c>
+/// leader templates, every one of them <c>culture="Culture.empire"</c>.
+///
+/// The engine never re-derives a culture for heroes built from those lists.
+/// <c>HeroCreator.CreateSpecialHero</c> leaves the culture unset, so
+/// <c>DefaultHeroCreationModel.GetCulture</c> falls through to the *template's*
+/// culture and ignores the born settlement entirely. Landing a companion
+/// (<c>CompanionRolesCampaignBehavior.SpawnNewHeroesForNewCompanionClan</c>) and
+/// a settlement rebellion (<c>RebellionsCampaignBehavior</c>) therefore produced
+/// Dunlendings in Erebor, Gondor, Mordor and everywhere else.
+/// </summary>
+[TestClass]
+public class CultureLordTemplateTests
+{
+    private const string LordTemplates = "lord_templates";
+    private const string RebellionHeroTemplates = "rebellion_hero_templates";
+
+    [TestMethod]
+    public void EveryLordTemplate_HasTheCultureOfTheCultureThatListsIt()
+    {
+        AssertTemplateListMatchesItsCulture(LordTemplates);
+    }
+
+    [TestMethod]
+    public void EveryRebellionHeroTemplate_HasTheCultureOfTheCultureThatListsIt()
+    {
+        AssertTemplateListMatchesItsCulture(RebellionHeroTemplates);
+    }
+
+    [TestMethod]
+    public void EveryCulture_ListsAtLeastOneLordTemplateAndOneRebellionHeroTemplate()
+    {
+        // MBReadOnlyList.GetRandomElement indexes straight into the list, so an
+        // empty one throws rather than degrading. Cultures that own no settlement
+        // are the documented exception — they never reach either code path.
+        var empty = new List<string>();
+        foreach (var culture in CulturesInSpCultures())
+        {
+            var id = culture.Attribute("id")?.Value;
+            if (string.IsNullOrEmpty(id) || LandlessCultures.Contains(id))
+                continue;
+
+            foreach (var listName in new[] { LordTemplates, RebellionHeroTemplates })
+            {
+                if (!ReferencedTemplateIds(culture, listName).Any())
+                    empty.Add($"{id}/{listName}");
+            }
+        }
+
+        Assert.AreEqual(0, empty.Count,
+            $"Cultures with an empty hero template list: {string.Join(", ", empty)}. " +
+            "GetRandomElement throws on an empty list — give the culture its own templates.");
+    }
+
+    private static void AssertTemplateListMatchesItsCulture(string listName)
+    {
+        var charactersByCulture = TaomCharacterCultures();
+        var offenders = new List<string>();
+
+        foreach (var culture in CulturesInSpCultures())
+        {
+            var cultureId = culture.Attribute("id")?.Value;
+            if (string.IsNullOrEmpty(cultureId))
+                continue;
+
+            foreach (var templateId in ReferencedTemplateIds(culture, listName))
+            {
+                if (!charactersByCulture.TryGetValue(templateId, out var owningCulture))
+                {
+                    offenders.Add($"{cultureId} -> {templateId} (not defined in TAOM ModuleData)");
+                    continue;
+                }
+
+                if (!string.Equals(owningCulture, cultureId, StringComparison.OrdinalIgnoreCase))
+                    offenders.Add($"{cultureId} -> {templateId} (culture={owningCulture ?? "unset"})");
+            }
+        }
+
+        Assert.AreEqual(0, offenders.Count,
+            $"Templates in <{listName}> that do not belong to the culture listing them: " +
+            $"{string.Join("; ", offenders)}. A hero built from one of these keeps the " +
+            "TEMPLATE's culture — DefaultHeroCreationModel.GetCulture never looks at the " +
+            "settlement — so it spawns with the wrong name pool, face and equipment.");
+    }
+
+    /// <summary>Cultures with no settlement of their own; neither code path can reach them.</summary>
+    private static readonly HashSet<string> LandlessCultures = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "dunland_raiders", "rhun_raiders", "harad_raiders", "gundabad_raiders",
+        "umbar_corsairs", "gondor_soldiers", "erebor_warriors", "mirkwood_stalkers"
+    };
+
+    private static IEnumerable<XElement> CulturesInSpCultures()
+    {
+        var path = Path.Combine(ModuleDataPath(), "taom_spcultures.xml");
+        Assert.IsTrue(File.Exists(path), $"taom_spcultures.xml not found at {path}");
+        return XDocument.Load(path).Descendants("Culture").ToList();
+    }
+
+    private static IEnumerable<string> ReferencedTemplateIds(XElement culture, string listName)
+    {
+        var list = culture.Element(listName);
+        if (list == null)
+            yield break;
+
+        foreach (var entry in list.Elements())
+        {
+            var reference = entry.Attribute("name")?.Value ?? entry.Attribute("id")?.Value;
+            if (!string.IsNullOrEmpty(reference))
+                yield return StripPrefix(reference);
+        }
+    }
+
+    /// <summary>Every NPCCharacter TAOM defines, mapped to its declared culture id.</summary>
+    private static Dictionary<string, string> TaomCharacterCultures()
+    {
+        var byId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var file in Directory.GetFiles(ModuleDataPath(), "*.xml", SearchOption.AllDirectories))
+        {
+            XDocument document;
+            try
+            {
+                document = XDocument.Load(file);
+            }
+            catch (System.Xml.XmlException)
+            {
+                continue;
+            }
+
+            foreach (var character in document.Descendants("NPCCharacter"))
+            {
+                var id = character.Attribute("id")?.Value;
+                if (string.IsNullOrEmpty(id))
+                    continue;
+
+                var culture = character.Attribute("culture")?.Value;
+                byId[id] = culture == null ? null : StripPrefix(culture);
+            }
+        }
+
+        return byId;
+    }
+
+    private static string StripPrefix(string reference)
+    {
+        var dot = reference.IndexOf('.');
+        return dot < 0 ? reference : reference.Substring(dot + 1);
+    }
+
+    private static string ModuleDataPath()
+    {
+        var dir = Directory.GetCurrentDirectory();
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir, "Main", "_Module", "ModuleData");
+            if (Directory.Exists(candidate))
+                return candidate;
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+
+        Assert.Fail("Could not locate Main/_Module/ModuleData from the test working directory.");
+        return null;
+    }
+}


### PR DESCRIPTION
Closes #411.

**Please review — not for merge until someone with an eye on lord equipment has looked at the two
new templates per culture.**

## The bug

A player granted a fief to a dwarf companion in Ered Luin. The new clan came out correctly Erebor —
it is named **Firebeard**, which is `aom_erebor_clan_5` — but the two clan members that spawned
with it are named **Graldor** and **Dunric**: `aom_dunland_male_name_29` and
`aom_dunland_male_name_2`.

All fourteen of TAOM's own cultures declare `<lord_templates>` **and**
`<rebellion_hero_templates>` as a verbatim copy of vanilla `empire`'s block — the same sixteen
`spc_legion_of_the_betrayed` / `spc_hidden_hand` / `spc_embers_of_flame` / `spc_eleftheroi`
leaders, every one of them `culture="Culture.empire"` in `SandBox/ModuleData/spspecialcharacters.xml`.
`spcultures.xslt` renames empire to the Dunlendings. `notable_templates` were authored properly per
culture; these two lists were missed when the empire culture was used as the skeleton.

The engine gets no second chance to correct it. `HeroCreator.CreateSpecialHero` never sets a
culture, so `InitializeHeroFromSettings` falls through to `DefaultHeroCreationModel.GetCulture`,
which returns `hero.CharacterObject.OriginalCharacter.Culture` — the **template's** culture. The
born settlement is passed in and ignored on that path. Whatever the template is, the hero is: name
pool, face, race, equipment.

Both readers are player-visible:

- `CompanionRolesCampaignBehavior.SpawnNewHeroesForNewCompanionClan` builds two lords from
  `companionHero.Culture.LordTemplates` every time a companion is granted a fief.
- `RebellionsCampaignBehavior` builds rebel leaders from `settlement.Culture.RebelliousHeroTemplates`,
  so a rising in a dwarf or Gondorian town was led by Dunlendings too.

The six XSLT-renamed vanilla cultures (Dunlending, Rohirrim, Haradrim, Easterling, Barding, Variag)
are **not** affected — the transform passes vanilla's own, self-consistent lists through.

## The fix

Each culture gets `spc_<culture>_lord_1` and `spc_<culture>_lord_2` in its own
`characters/npcs_<culture>.xml`, modelled on that culture's existing notable templates: its own
`race`, its own `BodyProperty.fighter_<culture>` face template, `skill_template` and
`default_group` matching the neighbouring templates, and a bold/cautious trait split of the kind
`spc_<culture>_headman_1/_2` already use. Both lists then point at them.

**No new art or equipment.** `equipmentsets/taom_lord_template_equipment.xml` already holds
`taom_<culture>_lord_battle_male` and `taom_<culture>_lord_civilian_male` for all twenty cultures.
Nothing in ModuleData referenced them by id; they were reachable only through the engine's
culture-and-flag search (`IsLordTemplate`) for child and coming-of-age equipment. The new templates
reference them directly, the same way `lord_E1_1` references `dain_bat_equipment`.

Two templates per culture rather than vanilla's sixteen: two is what a landing spawns, and a third
would need equipment that does not exist yet. Male only — vanilla's sixty `spc_*_leader_*` templates
are all male, and TAOM ships no female character template of any occupation today, so the
`_female` rosters in that file stay unused and female lord templates stay a deliberate follow-up.

The existing `child_education_templates_*_<culture>` entries are `occupation="Lord"` and
culture-correct, but they carry no `race` attribute and no weapons, so they could not be reused.

## Regression cover

`TAOM.Tests/Core/CultureLordTemplateTests.cs`:

- every template a culture lists must be defined in TAOM's ModuleData and carry that culture, for
  both lists;
- neither list may be empty — `MBReadOnlyList.GetRandomElement` indexes straight into the list and
  throws on an empty one. Landless cultures are exempt; neither code path reaches them.

RED before the fix: **204** offending entries in `lord_templates`, **200** in
`rebellion_hero_templates`, named culture by culture in the assertion message.

## Verification

`dotnet test TAOM.Tests -p:DisableModuleCopy=true`, against the installed 1.4.7 reference assemblies:

| | Failed | Passed |
|---|---|---|
| `bannerlord-1.4.5` + the new test, data unchanged | 8 | 5843 |
| this branch | **6** | **5845** |

The same six failures in both columns, all pre-existing on the base branch and untouched here:
`OnSessionLaunched_RegistersFiefHubMenuAndOptions`,
`ShippedCultures_EveryBannerBearerReplacementWeaponIsOneHanded`,
`Wave1Feats_ProductionMetadata_MatchesSpec`, `EveryBoolPrefix_HasACoopDisposition`,
`Registry_HasNoStaleEntries`,
`EveryConsumerOfADivergenceProneDiplomacyRule_AlsoReadsTheCoopFlag` (the last four throw
`DirectoryNotFoundException` on source paths that do not exist on this branch). Every changed XML
file re-parses.

> **Note on the base branch, unrelated to this PR:** `bannerlord-1.4.5` at `f6a35644` does not
> compile. `Main/Features/Enlistment/EnlistmentDiagnosticsSettingsProvider.cs:20` reads
> `TaomSettings.EnableEnlistmentDiagnostics`, and no file on the branch declares it — `dotnet build
> Main/TAOM.csproj` fails with `CS1061` on a clean checkout with no local changes. To run the suite
> at all I stubbed that one property locally; **the stub is not in this PR** (the diff is 15
> ModuleData XMLs, one test, and CHANGELOG). Worth a fix on its own.

## Save impact

Heroes already created keep the culture stored on them. This changes what spawns from here on, not
what has already spawned — existing wrong-culture vassal underlings would need a separate one-off
rewrite.

## Two things this PR deliberately does not fix

1. **`tournament_team_templates_one_participant`** is `tournament_template_empire_one_participant_set_v1`
   for every culture, from the same copy-paste. Left alone — tournament teams are their own content
   question.
2. **Nashga**, the third name in the report, is not explained by this bug. She is not in any
   generated-name pool; she is the world-gen named lord `lord_MM14_7`
   (`Culture.mistymountainorcs`, `clan_mistymountainorcs_14`, spouse `lord_MM14_2` Durbash). A
   pre-existing named lord can only enter a player-vassal's clan through an existing-hero route —
   vanilla AI marriage being the obvious one, and this bug hands that clan two unmarried adult
   males. Detail in #411.

Also noted in #411, and also not this PR: vanilla's
`CompanionsCampaignBehavior.InitializeCompanionTemplateList` collects every wanderer template in the
game with no culture filter, so TAOM taverns offer wanderers of any culture. That is the likelier
source of "or they get orcs" if the reporter meant recruitable companions.
