### PR TITLE
fix(tools): ten tools that write to the game install take an override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@
 
 ## 2026-08-07
 
+### fix(tools): the ten tools that write into the game install now honour BANNERLORD_GAME_DIR (#404)
+
+#401 fixed the five diagnostics that only read. The tools that *write* are the sharper edge: with the
+literal wrong they do not fail, they edit whichever install
+`E:\Steam\steamapps\common\Mount & Blade II Bannerlord` happens to name. Seven of them write under
+`TAOM_Map`, where the repo copy is a stale shadow and the live module is authoritative, so a write to
+the wrong root is silent.
+
+Each now resolves `os.environ.get("BANNERLORD_GAME_DIR") or <existing literal>` and derives its path
+from that. The `or` form rather than #401's `get(VAR, default)` because an exported-but-blank variable
+returns `""` and `Path("")` is `.` — #404 point 4. The literal stays as the fallback, so behaviour is
+unchanged where the variable is unset.
+
+The read/write split in the issue is 9/4; resolving every write call to its target root makes it
+10/3. `clan_registry.py` only reads the game (vanilla `spclans.xml`, line 87) and writes to
+`docs/reviews/_clan_registry.json` inside the repo, so it moves out of the writers.
+`rebuild_translation_files.py` and `remap_stale_scene_names.py`, both listed as readers, move in:
+the first writes `loc_settlements.xml` and the Armory `loc_*.xml` files straight into the install with
+no `--apply` gate, the second rewrites the live `settlements.xml` under `--apply`. Of the four listed
+readers only `audit_item_refs.py` (no write calls at all) and `apply_erebor_equipment_sweep.py` (reads
+the install, writes `Main/_Module/.../troops_erebor.xml` in the repo) actually are ones.
+
+Verified against a throwaway `Modules` tree holding copies of the two affected `ModuleData` folders
+(515 files), with an MD5 manifest of the real install taken before and after every round: unchanged
+throughout. Output is identical to the previous version both unset and with the variable
+set to the tool's own literal — the only diffs were traceback line numbers, shifted by the added
+lines. The control run matters more than the pass: with the fix reverted and the variable pointing at
+the throwaway tree, none of the ten touch it; with the fix in place, seven write there (the other
+three no-op for their own reasons — idempotent, nothing to roll back, and assets absent from this
+install).
+
+One pre-existing behaviour left alone as out of scope for this change: pointed at a root that does not
+exist, `rebuild_translation_files.py` creates the whole
+`Modules/LOTRLOME_Armory/ModuleData/Languages/<lang>` chain there and exits 0.
+`rollback_erebor_iron_misfile.py` and `cleanup_deleted_gondor_armor.py` also exit 0 on a wrong root
+while doing nothing. That is the case #404 point 4 wants a shared helper for.
+
 ### fix(troopweight): shed-on-upgrade was deleting every settlement's militia down to ~20
 
 A player reported that every settlement held between 20 and 26 militia and stayed there, while the

--- a/tools/Apply-MapVillageNames.py
+++ b/tools/Apply-MapVillageNames.py
@@ -499,7 +499,10 @@ if len(set(NAMES.values())) != len(NAMES.values()):
     raise SystemExit("Duplicate names; aborting")
 print("All names unique.")
 
-ROOT = r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules\TAOM_Map\ModuleData"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+ROOT = GAME + r"\Modules\TAOM_Map\ModuleData"
 LANGS = ["BR", "CNs", "CNt", "DE", "FR", "IT", "JP", "KO", "PL", "RU", "SP", "TR"]
 
 

--- a/tools/Assign-SettlementOwners.py
+++ b/tools/Assign-SettlementOwners.py
@@ -36,7 +36,10 @@ import re
 import sys
 from collections import Counter
 
-ROOT = r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules\TAOM_Map\ModuleData"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+ROOT = GAME + r"\Modules\TAOM_Map\ModuleData"
 SETTLEMENTS = os.path.join(ROOT, "settlements.xml")
 
 # ---------------------------------------------------------------------------

--- a/tools/add_bluecraig_castles.py
+++ b/tools/add_bluecraig_castles.py
@@ -20,9 +20,12 @@ Usage:
   python tools/add_bluecraig_castles.py            # dry-run (prints plan)
   python tools/add_bluecraig_castles.py --apply    # writes the live file (+ backup)
 """
-import argparse, re, shutil, datetime, xml.etree.ElementTree as ET
+import argparse, os, re, shutil, datetime, xml.etree.ElementTree as ET
 
-LIVE = r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord/Modules/TAOM_Map/ModuleData/settlements.xml"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
+LIVE = GAME + r"/Modules/TAOM_Map/ModuleData/settlements.xml"
 VALID_VILLAGE_TYPES = {"swine_farm", "cattle_farm", "sheep_farm", "wheat_farm", "vineyard",
                        "fisherman", "lumberjack", "iron_mine", "silver_mine", "clay_mine",
                        "salt_mine", "flax_plant", "date_farm", "olive_trees", "silk_plant", "trapper"}

--- a/tools/assign_orc_village_types.py
+++ b/tools/assign_orc_village_types.py
@@ -17,10 +17,13 @@ Usage:
   python tools/assign_orc_village_types.py            # dry-run (prints plan)
   python tools/assign_orc_village_types.py --apply    # writes live file (+ backup)
 """
-import argparse, re, shutil
+import argparse, os, re, shutil
 from datetime import datetime
 
-LIVE = r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord/Modules/TAOM_Map/ModuleData/settlements.xml"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
+LIVE = GAME + r"/Modules/TAOM_Map/ModuleData/settlements.xml"
 ORC_CULTURES = {"goblin", "mistymountainorcs"}  # bluecraig villages (culture goblin) covered when added
 # v1.4.5 VillageType stringIds are CODE-registered in DefaultVillageTypes (NOT XML) — verify against the
 # engine, never a plausible name. "cattle_range" does NOT exist (it's "cattle_farm"); using an unregistered

--- a/tools/cleanup_deleted_gondor_armor.py
+++ b/tools/cleanup_deleted_gondor_armor.py
@@ -10,13 +10,18 @@ Usage:
 """
 
 import argparse
+import os
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+# The E:/repos asset-repo entry is a different concept and keeps its own literal.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or "E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
 ARMORY_PATHS = [
     Path("E:/repos/lotraom-assets/shared/LOTRLOME_Armory/ModuleData/LOTRLOME_items/gondor"),
-    Path("E:/Steam/steamapps/common/Mount & Blade II Bannerlord/Modules/LOTRLOME_Armory/ModuleData/LOTRLOME_items/gondor"),
+    Path(GAME) / "Modules/LOTRLOME_Armory/ModuleData/LOTRLOME_items/gondor",
 ]
 
 # Item IDs to remove, grouped by source XML file

--- a/tools/generate_new_faction_settlements.py
+++ b/tools/generate_new_faction_settlements.py
@@ -25,7 +25,10 @@ from assign_orc_village_types import fief_types, ORC_CULTURES  # per-fief orc vi
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 LAYOUT = os.path.join(ROOT, "tools", "taom_new_factions_layout.json")
-LIVE = r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord/Modules/TAOM_Map/ModuleData/settlements.xml"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
+LIVE = GAME + r"/Modules/TAOM_Map/ModuleData/settlements.xml"
 
 # ---- Curated display names (placeholders, lore-flavoured; user can rename freely) ----
 NAMES = {

--- a/tools/patch_quad_movement.py
+++ b/tools/patch_quad_movement.py
@@ -10,7 +10,10 @@ Structure (v2 single-item AnimationClip _anm.tpac):
 """
 import struct, os, shutil
 
-DIR = r'E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules\LOTRLOME_Armory\Assets\creature\chariot\animations'
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get('BANNERLORD_GAME_DIR') or r'E:\Steam\steamapps\common\Mount & Blade II Bannerlord'
+DIR = GAME + r'\Modules\LOTRLOME_Armory\Assets\creature\chariot\animations'
 PAIRS = [  # (target, donor) — donor is a tagged sibling of the same gait direction
     ('chariot_gait_walkfast_anm.tpac',     'chariot_walkfast_anm.tpac'),
     ('chariot_gait_walkbackfast_anm.tpac', 'chariot_walkbackfast_anm.tpac'),

--- a/tools/rebuild_translation_files.py
+++ b/tools/rebuild_translation_files.py
@@ -13,13 +13,17 @@ Usage: python tools/rebuild_translation_files.py --lang RU
 
 import argparse
 import json
+import os
 import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-GAME_ROOT = Path(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules")
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+GAME_ROOT = Path(GAME) / "Modules"
 
 LANGUAGES = {
     "BR":  ("por-BR", "Portuguese (Brazilian)"),

--- a/tools/remap_stale_scene_names.py
+++ b/tools/remap_stale_scene_names.py
@@ -18,10 +18,14 @@ Usage:
 """
 from __future__ import annotations
 import argparse
+import os
 import re
 from pathlib import Path
 
-GAME = Path(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = Path(os.environ.get("BANNERLORD_GAME_DIR")
+            or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
 MODULES = GAME / "Modules"
 LIVE = MODULES / "TAOM_Map" / "ModuleData" / "settlements.xml"
 SHADOW = Path(__file__).resolve().parent.parent / "Main" / "_Module" / "ModuleData" / "settlements.xml"

--- a/tools/rollback_erebor_iron_misfile.py
+++ b/tools/rollback_erebor_iron_misfile.py
@@ -17,10 +17,10 @@ import os
 import re
 import sys
 
-EREBOR_DIR = (
-    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
-    r"\Modules\LOTRLOME_Armory\ModuleData\LOTRLOME_items\erebor"
-)
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+EREBOR_DIR = GAME + r"\Modules\LOTRLOME_Armory\ModuleData\LOTRLOME_items\erebor"
 
 # Section header inserted by generate_erebor_armor.py
 SECTION_RE = re.compile(


### PR DESCRIPTION
Closes part 1 of #404 for the writers, which the issue asks to do first.

## What changed

Ten tools now resolve `os.environ.get("BANNERLORD_GAME_DIR") or <existing literal>` and derive their
own path from that. The literal is preserved as the fallback, so nothing changes on a machine where
the variable is unset.

`Assign-SettlementOwners.py` · `Apply-MapVillageNames.py` · `add_bluecraig_castles.py` ·
`assign_orc_village_types.py` · `generate_new_faction_settlements.py` · `patch_quad_movement.py` ·
`rollback_erebor_iron_misfile.py` · `cleanup_deleted_gondor_armor.py` ·
`rebuild_translation_files.py` · `remap_stale_scene_names.py`

## Two deviations from the issue text, both deliberate

**The `or` form instead of `get(VAR, default)`.** The issue asks for the exact shape from #401, but
that shape is the one point 4 of the same issue describes as broken: an exported-but-blank variable
returns `""`, and `Path("")` is `.`. Copying it would propagate that to ten more call sites, then
point 4 would have to revisit all of them. `os.environ.get(VAR) or <literal>` already exists in the
repo at `rebalance_armor.py:33` and treats blank as unset. It is not the full fix point 4 asks for —
that is the shared helper, and it should land once, adopted by these ten and the five from #401
together, rather than half of it here.

**Ten writers, not nine.** Resolving every write call in the thirteen to its target root gives a
10/3 split rather than 9/4:

| tool | issue says | write calls resolve to |
|---|---|---|
| `clan_registry.py` | writer | reads vanilla `spclans.xml` (line 87); its one write is `docs/reviews/_clan_registry.json` in the repo (line 129) |
| `rebuild_translation_files.py` | reader | writes `TAOM_Map/.../loc_settlements.xml` (line 175) and the Armory `loc_*.xml` (line 192) into the install, with no `--apply` gate |
| `remap_stale_scene_names.py` | reader | rewrites the live `settlements.xml` under `--apply` (lines 100, 127) |

Of the four listed readers, `audit_item_refs.py` (no write calls at all) and
`apply_erebor_equipment_sweep.py` (reads the install, writes `Main/_Module/.../troops_erebor.xml` in
the repo) are the ones that hold. This PR covers all ten writers; the three genuine readers and
items 2-4 of the issue are left for a follow-up.

## Verification

A throwaway `Modules` tree outside the game held copies of the two affected `ModuleData` folders
(515 files), and an MD5 manifest of the real install was taken before and after every round.

| check | result |
|---|---|
| output vs the previous version, variable unset | identical, 10/10 |
| output vs the previous version, variable set to each tool's own literal | identical, 10/10 |
| variable pointed at the throwaway tree, `--apply` | 7 write there; 3 no-op |
| **control: fix reverted, same variable** | **0 of 10 touch the throwaway tree** |
| real install after every round | unchanged, aggregate MD5 `1ECA063B83329D3F552565C705CFA9ED` |

The only diffs in the first two rows were traceback line numbers, shifted by the added lines;
normalised, they are byte-identical. One caveat on the "set to the literal" row: the literals are a
mix of forward and backslash styles, so a tool matches when the variable is set in its own style.
Setting the opposite style still resolves correctly on Windows, it just prints mixed separators.

The three that no-op against the throwaway tree do so for their own reasons, and each read it:
`add_bluecraig_castles` reports the castles already present (idempotent), `rollback_erebor_iron_misfile`
finds no `sk_dwarf_iron_*` items to remove, and `patch_quad_movement` fails naming the throwaway path
because `LOTRLOME_Armory/Assets` is absent from this install. That last one means its full patch cycle
was not exercised here, only the redirection.

## One finding for the follow-up

Pointed at a root that does not exist, `rebuild_translation_files.py` creates the whole
`Modules/LOTRLOME_Armory/ModuleData/Languages/<lang>` chain there and exits 0.
`rollback_erebor_iron_misfile.py`, `cleanup_deleted_gondor_armor.py` and `remap_stale_scene_names.py`
also exit 0 on a wrong root while doing nothing — `remap` reports `0 of 13 remaps match the live
file`, which reads like a clean result. This is pre-existing and untouched here; it is the same
silent-success shape as the `validate_moduledata.py` case in the issue comment, and the argument for
point 4's shared helper.
