### PR TITLE
feat(tools): one place answers where the install is, wrong roots say so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ every file missing instead of the root being wrong. `game_dir` treats blank as u
 covering that case fail against the old shape, which is how we know they test something:
 `'' != 'E:\\Steam\\...'`.
 
+Point 4 has an inverse the issue does not name, and it is the more expensive half: a wrong root that
+makes a tool invent a catastrophe rather than hide one. Three reference validators build their
+registry from the install and treat "not defined" as "broken", so an absent root registers nothing
+and condemns everything:
+
+| tool | wrong root | true answer |
+|---|---|---|
+| `audit_item_refs.py` | `Total broken refs: 35443 sites across 2897 item IDs`, exit 0 | `0 sites across 0 item IDs` |
+| `validate_all_troop_refs.py` | `FAIL: 1488 armor refs do not resolve`, exit 1 | `PASS` |
+| `validate_gondor_refs.py` | `FAIL: missing references will cause underwear bug in-game`, exit 1 | `PASS` |
+
+The two that exit 1 are worse than the one that exits 0: exit 1 means "the data is broken", and
+`validate_all_troop_refs.py` is the underwear-bug gate `tools/README.md` points at. A fabricated
+failure there costs as much as a missed one. All three now exit 2 naming the folder they could not
+read. (`validate_mesh_refs.py` shares the shape but not the bug — its root is absent here too and it
+already exits 2 saying so; it takes `--items` / `--game` rather than the variable.)
+
 `ensure_exists` went to the four places measured to end on a clean-looking result against a root that
 is not there. All four exited 0 before; they exit 2 with the path named now. `rollback_erebor_iron_misfile.py`
 printed five `SKIP: <file> not found` lines and `Total removed: 0`. `cleanup_deleted_gondor_armor.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## 2026-08-07
 
+### fix(tools): a degraded validate_moduledata run stops reporting PASS as a pass (#404)
+
+`validate_moduledata.py` took its Modules folder from a literal, so on a wrong root the registry came
+back with 0 items and 0 NPCCharacters, `BROKEN_ITEM_REF` and `BROKEN_TROOP_REF` could not fire, and
+the run still printed `PASS` and exited 0. It now resolves the folder through `_gamedir.game_modules`
+(aliased on import, since `main()` binds a local of the same name), and a run whose root is missing
+returns 2 rather than 0. The commit hook already fails open on anything that is not 1, so nothing
+starts blocking that did not block before.
+
+Measured on this machine: with the root right, `Registry: 5,952 items, 5,005 NPCCharacters` and
+`PASS`, exit 0. With it wrong, `Registry: 0 items, 0 NPCCharacters`, `PASS`, and now exit 2.
+
+The hook itself needed no change: `BANNERLORD_GAME_DIR` is a persistent user variable, so every
+process it spawns inherits it.
+
 ### feat(tools): one place answers "where is the install", and a wrong root says so (#404)
 
 Completes #404 on top of the writers. `tools/_gamedir.py` holds `game_dir(default)`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@
 
 ## 2026-08-07
 
+### feat(tools): one place answers "where is the install", and a wrong root says so (#404)
+
+Completes #404 on top of the writers. `tools/_gamedir.py` holds `game_dir(default)`,
+`game_modules(default)` and `ensure_exists(path, what=...)`; 21 tools resolve through it.
+
+`os.environ.get("BANNERLORD_GAME_DIR", default)` — the shape #401 established and seven tools still
+carried — returns `""` for an exported-but-blank variable, and `Path("")` is `.`, so the tool reports
+every file missing instead of the root being wrong. `game_dir` treats blank as unset. The two tests
+covering that case fail against the old shape, which is how we know they test something:
+`'' != 'E:\\Steam\\...'`.
+
+`ensure_exists` went to the four places measured to end on a clean-looking result against a root that
+is not there. All four exited 0 before; they exit 2 with the path named now. `rollback_erebor_iron_misfile.py`
+printed five `SKIP: <file> not found` lines and `Total removed: 0`. `cleanup_deleted_gondor_armor.py`
+printed `Grand total: 0`. `remap_stale_scene_names.py` printed `0 of 13 remaps match the live file`,
+which reads as "already done". `rebuild_translation_files.py` was the worst of them: `mkdir(parents=True)`
+built the whole `Modules/LOTRLOME_Armory/ModuleData/Languages/<lang>` chain under the bogus root,
+found no `loc_*.xml` to read, and still finished on `Done.`
+
+`taom_mcp_server.py` now derives its Modules folder from `BANNERLORD_GAME_DIR` and keeps
+`BANNERLORD_GAME_MODULES` as an explicit override, so one variable is enough for a correct setup —
+a server answering `item_exists` against the previous install is hard to notice. `tools/.env.example`
+gains both `BANNERLORD_*` names.
+
+`dump_settlement_buildings.py`, `rebalance_armor.py` and `rebalance_settlement_prosperity.py` were
+left on their own inline resolution on purpose: they already use the `or` form, so they do not have
+the blank-variable defect, and two of them define a local `game_dir()` the import would shadow. The
+win would have been uniformity alone, against renames in files this work does not otherwise touch.
+
+Six of the ten from the previous entry kept their inline `or` until this pass converted them too —
+two forms inside one change is the drift the issue is about. Their output is unchanged: the six that
+gained nothing but the helper are byte-identical to the previous version with the variable unset, and
+the four that gained `ensure_exists` change exactly where they were meant to. Python suite: 400 tests,
+up from 387, green on 3.14.
+
+Running it first on 3.11 gave 3 errors in `test_translate_batching`, which looked pre-existing and
+unrelated — it is both, but the reason is worth recording. `Path.read_text(newline=)` landed in 3.13,
+so the suite is red on any older interpreter, and `python` on PATH here is 3.11.9 while the `py`
+launcher defaults to 3.14. Four tools use the same keyword outside the tests
+(`generate_lord_template_equipment.py`, two under `oneoff/`), so the floor for parts of `tools/` is
+genuinely 3.13, while the docs still say 3.9+ / 3.10+ / 3.11+ in different places. Not this change's
+to fix; noted so the next person does not read the red as breakage.
+
 ### fix(tools): the ten tools that write into the game install now honour BANNERLORD_GAME_DIR (#404)
 
 #401 fixed the five diagnostics that only read. The tools that *write* are the sharper edge: with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@
 
 ## 2026-08-07
 
+### fix(tools): the ten tools that write into the game install now honour BANNERLORD_GAME_DIR (#404)
+
+#401 fixed the five diagnostics that only read. The tools that *write* are the sharper edge: with the
+literal wrong they do not fail, they edit whichever install
+`E:\Steam\steamapps\common\Mount & Blade II Bannerlord` happens to name. Seven of them write under
+`TAOM_Map`, where the repo copy is a stale shadow and the live module is authoritative, so a write to
+the wrong root is silent.
+
+Each now resolves `os.environ.get("BANNERLORD_GAME_DIR") or <existing literal>` and derives its path
+from that. The `or` form rather than #401's `get(VAR, default)` because an exported-but-blank variable
+returns `""` and `Path("")` is `.` — #404 point 4. The literal stays as the fallback, so behaviour is
+unchanged where the variable is unset.
+
+The read/write split in the issue is 9/4; resolving every write call to its target root makes it
+10/3. `clan_registry.py` only reads the game (vanilla `spclans.xml`, line 87) and writes to
+`docs/reviews/_clan_registry.json` inside the repo, so it moves out of the writers.
+`rebuild_translation_files.py` and `remap_stale_scene_names.py`, both listed as readers, move in:
+the first writes `loc_settlements.xml` and the Armory `loc_*.xml` files straight into the install with
+no `--apply` gate, the second rewrites the live `settlements.xml` under `--apply`. Of the four listed
+readers only `audit_item_refs.py` (no write calls at all) and `apply_erebor_equipment_sweep.py` (reads
+the install, writes `Main/_Module/.../troops_erebor.xml` in the repo) actually are ones.
+
+Verified against a throwaway `Modules` tree holding copies of the two affected `ModuleData` folders
+(515 files), with an MD5 manifest of the real install taken before and after every round: unchanged
+throughout. Output is identical to the previous version both unset and with the variable
+set to the tool's own literal — the only diffs were traceback line numbers, shifted by the added
+lines. The control run matters more than the pass: with the fix reverted and the variable pointing at
+the throwaway tree, none of the ten touch it; with the fix in place, seven write there (the other
+three no-op for their own reasons — idempotent, nothing to roll back, and assets absent from this
+install).
+
+One pre-existing behaviour left alone as out of scope for this change: pointed at a root that does not
+exist, `rebuild_translation_files.py` creates the whole
+`Modules/LOTRLOME_Armory/ModuleData/Languages/<lang>` chain there and exits 0.
+`rollback_erebor_iron_misfile.py` and `cleanup_deleted_gondor_armor.py` also exit 0 on a wrong root
+while doing nothing. That is the case #404 point 4 wants a shared helper for.
+
 ### fix(troopweight): shed-on-upgrade was deleting every settlement's militia down to ~20
 
 A player reported that every settlement held between 20 and 26 militia and stayed there, while the

--- a/tools/.env.example
+++ b/tools/.env.example
@@ -2,6 +2,17 @@
 # Copy this file to .env and set values matching your machine.
 # Scripts fall back to the hardcoded defaults if these are unset.
 
+# Bannerlord install root. This is the main one: the tools that read or write
+# the live modules derive their paths from it, so setting this alone is enough
+# for a correct setup. setup-dev-env.ps1 sets it and README.md requires it.
+# Default: E:\Steam\steamapps\common\Mount & Blade II Bannerlord
+BANNERLORD_GAME_DIR=
+
+# The Modules folder, named directly. Only needed when it does not sit under
+# BANNERLORD_GAME_DIR; it overrides the value derived from it.
+# Default: <BANNERLORD_GAME_DIR>\Modules
+BANNERLORD_GAME_MODULES=
+
 # Full path to the downloaded map PNG used by faction map scripts
 # Default: C:\Users\mikew\Downloads\Vista_dot-settlements-with-borders.png
 TAOM_MAP_IMAGE=

--- a/tools/Apply-MapVillageNames.py
+++ b/tools/Apply-MapVillageNames.py
@@ -499,7 +499,10 @@ if len(set(NAMES.values())) != len(NAMES.values()):
     raise SystemExit("Duplicate names; aborting")
 print("All names unique.")
 
-ROOT = r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules\TAOM_Map\ModuleData"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+ROOT = GAME + r"\Modules\TAOM_Map\ModuleData"
 LANGS = ["BR", "CNs", "CNt", "DE", "FR", "IT", "JP", "KO", "PL", "RU", "SP", "TR"]
 
 

--- a/tools/Apply-MapVillageNames.py
+++ b/tools/Apply-MapVillageNames.py
@@ -34,6 +34,7 @@ See docs/reference/taom-map-settlement-naming.md for:
 Last bulk-applied: 2026-05-26 (345 village display names across 15 regions).
 """
 import os, re
+from _gamedir import game_dir
 
 NAMES = {
     # V - Rohan (Anglo-Saxon)
@@ -501,7 +502,7 @@ print("All names unique.")
 
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+GAME = game_dir(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
 ROOT = GAME + r"\Modules\TAOM_Map\ModuleData"
 LANGS = ["BR", "CNs", "CNt", "DE", "FR", "IT", "JP", "KO", "PL", "RU", "SP", "TR"]
 

--- a/tools/Assign-SettlementOwners.py
+++ b/tools/Assign-SettlementOwners.py
@@ -35,10 +35,11 @@ import os
 import re
 import sys
 from collections import Counter
+from _gamedir import game_dir
 
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+GAME = game_dir(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
 ROOT = GAME + r"\Modules\TAOM_Map\ModuleData"
 SETTLEMENTS = os.path.join(ROOT, "settlements.xml")
 

--- a/tools/Assign-SettlementOwners.py
+++ b/tools/Assign-SettlementOwners.py
@@ -36,7 +36,10 @@ import re
 import sys
 from collections import Counter
 
-ROOT = r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules\TAOM_Map\ModuleData"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+ROOT = GAME + r"\Modules\TAOM_Map\ModuleData"
 SETTLEMENTS = os.path.join(ROOT, "settlements.xml")
 
 # ---------------------------------------------------------------------------

--- a/tools/README.md
+++ b/tools/README.md
@@ -292,18 +292,27 @@ See `docs/localization/TRANSLATOR_GUIDE.md` for the translator-facing workflow +
 **AI translation (translate_with_claude.py only):** `anthropic` SDK
 
 **Game install — set `BANNERLORD_GAME_DIR`.** `README.md` lists it as a prerequisite and
-`setup-dev-env.ps1` sets it. 18 tools honour it: 14 read it directly, and `analyze_armor_balance.py`,
+`setup-dev-env.ps1` sets it. 28 tools honour it: 24 resolve it themselves, and `analyze_armor_balance.py`,
 `apply_settlement_buildings.py`, `derive_armor_tiers.py` and `generate_enlistment_rosters.py` inherit it
 by importing one that does. Every one falls back to `E:\Steam\steamapps\common\Mount & Blade II Bannerlord`, so leaving it unset changes
 nothing on a machine where that literal is correct.
 
-Three narrower variables are **not** derived from it — set them separately if you use those tools:
-`BANNERLORD_GAME_MODULES` (`taom_mcp_server.py`), `TAOM_ARMORY_BASE` (`cleanup_deleted_gondor_items.py`),
-`TAOM_MAP_FILE` (`merge_settlements.py`). `tools/.env.example` documents the `TAOM_*` pair but not
-`BANNERLORD_GAME_DIR`.
+**Resolve it through `tools/_gamedir.py`** — 21 of the 24 do. `game_dir(default)` treats a set-but-blank
+variable as unset, which `os.environ.get(VAR, default)` does not: it returns `""`, `Path("")` is `.`, and
+the tool then reports every file missing rather than the root being wrong. `game_modules(default)` adds
+the `BANNERLORD_GAME_MODULES` precedence, and `ensure_exists(path, what=...)` exits 2 naming the path,
+for the tools that would otherwise end on a clean-looking result against a root that is not there.
+`dump_settlement_buildings.py`, `rebalance_armor.py` and `rebalance_settlement_prosperity.py` keep their
+own inline resolution: they already handle the blank case, and two of them define a local `game_dir()`
+that the import would shadow.
 
-**Thirteen top-level tools still have no override at all**, nine of which write rather than read — read
-the source before pointing one at a non-default install (#404).
+`taom_mcp_server.py` derives its Modules folder from `BANNERLORD_GAME_DIR`, keeping
+`BANNERLORD_GAME_MODULES` as an explicit override. Two narrower variables are still **not** derived from
+it — set them separately if you use those tools: `TAOM_ARMORY_BASE` (`cleanup_deleted_gondor_items.py`)
+and `TAOM_MAP_FILE` (`merge_settlements.py`). `tools/.env.example` documents all four.
+
+The thirteen top-level tools that had no override of any kind now all read `BANNERLORD_GAME_DIR` (#404).
+Six others were left alone deliberately: they take a path flag, which is override enough.
 
 **Other hardcoded paths** (update if your environment differs):
 - TAOM repo: `c:\Users\mikew\source\repos\TAOM\` — `generate_xslt.py`, `blender/rebuild_anim_from_json.py`

--- a/tools/_gamedir.py
+++ b/tools/_gamedir.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""One place to answer "where is the Bannerlord install".
+
+Tools under tools/ carry an install path as their default. That literal is one
+machine's; BANNERLORD_GAME_DIR is the override README.md requires and
+setup-dev-env.ps1 sets. Keeping the resolution here rather than inline buys two
+things a plain `os.environ.get(VAR, default)` does not:
+
+  * A set-but-blank variable is treated as unset. `os.environ.get` returns `""`
+    for an exported-but-empty variable and `Path("")` is `.`, so the tool goes
+    on to report every file missing instead of saying the root is wrong.
+
+  * `ensure_exists` states plainly that a root is not there. Several tools
+    otherwise finish with a clean-looking result on a wrong root — printing
+    SKIP lines, or "0 of 13 remaps match", and exiting 0. A wrong root is the
+    caller's to fix, so say so (`.claude/rules/environment-failures.md`).
+
+Both were raised in issue #404. Import it as a sibling module — tools run as
+`python tools/<name>.py`, so tools/ is already on sys.path:
+
+    from _gamedir import game_dir
+    GAME = game_dir(r"E:\\Steam\\steamapps\\common\\Mount & Blade II Bannerlord")
+"""
+import os
+import sys
+from pathlib import Path
+
+ENV_VAR = "BANNERLORD_GAME_DIR"
+MODULES_ENV_VAR = "BANNERLORD_GAME_MODULES"
+
+
+def game_dir(default):
+    """The install root: $BANNERLORD_GAME_DIR when it names something, else `default`.
+
+    Returns a `str`, verbatim, so a caller composing `GAME + r"\\Modules\\..."`
+    keeps the separator style its own literal used. A variable that is set but
+    blank (or only whitespace) counts as unset.
+    """
+    value = os.environ.get(ENV_VAR)
+    if value is None or not value.strip():
+        return default
+    return value
+
+
+def game_modules(default):
+    """The `Modules` folder, as a `Path`, from whichever variable is set.
+
+    $BANNERLORD_GAME_MODULES predates $BANNERLORD_GAME_DIR and names the folder
+    directly, so it stays as the explicit override and wins. Otherwise this
+    derives from the install root, which means setting one variable is enough
+    for a correct setup — a server answering queries against the previous
+    install is hard to notice. `default` is the install root, not the Modules
+    folder.
+    """
+    override = os.environ.get(MODULES_ENV_VAR)
+    if override is not None and override.strip():
+        return Path(override)
+    return Path(game_dir(default)) / "Modules"
+
+
+def ensure_exists(path, what="the Bannerlord install"):
+    """Return `path` as a `Path`, or exit 2 saying it is not there.
+
+    Call this where the tool would otherwise carry on and report a result that
+    reads as clean. Exit 2 rather than 1 keeps "bad input" distinct from "found
+    something wrong with the data".
+    """
+    resolved = Path(path)
+    if resolved.exists():
+        return resolved
+    print(f"ERROR: {what} not found at {resolved}", file=sys.stderr)
+    print(f"       Set ${ENV_VAR} to your Bannerlord install root.", file=sys.stderr)
+    raise SystemExit(2)

--- a/tools/add_bluecraig_castles.py
+++ b/tools/add_bluecraig_castles.py
@@ -20,11 +20,12 @@ Usage:
   python tools/add_bluecraig_castles.py            # dry-run (prints plan)
   python tools/add_bluecraig_castles.py --apply    # writes the live file (+ backup)
 """
-import argparse, os, re, shutil, datetime, xml.etree.ElementTree as ET
+import argparse, re, shutil, datetime, xml.etree.ElementTree as ET
+from _gamedir import game_dir
 
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
+GAME = game_dir(r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord")
 LIVE = GAME + r"/Modules/TAOM_Map/ModuleData/settlements.xml"
 VALID_VILLAGE_TYPES = {"swine_farm", "cattle_farm", "sheep_farm", "wheat_farm", "vineyard",
                        "fisherman", "lumberjack", "iron_mine", "silver_mine", "clay_mine",

--- a/tools/add_bluecraig_castles.py
+++ b/tools/add_bluecraig_castles.py
@@ -20,9 +20,12 @@ Usage:
   python tools/add_bluecraig_castles.py            # dry-run (prints plan)
   python tools/add_bluecraig_castles.py --apply    # writes the live file (+ backup)
 """
-import argparse, re, shutil, datetime, xml.etree.ElementTree as ET
+import argparse, os, re, shutil, datetime, xml.etree.ElementTree as ET
 
-LIVE = r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord/Modules/TAOM_Map/ModuleData/settlements.xml"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
+LIVE = GAME + r"/Modules/TAOM_Map/ModuleData/settlements.xml"
 VALID_VILLAGE_TYPES = {"swine_farm", "cattle_farm", "sheep_farm", "wheat_farm", "vineyard",
                        "fisherman", "lumberjack", "iron_mine", "silver_mine", "clay_mine",
                        "salt_mine", "flax_plant", "date_farm", "olive_trees", "silk_plant", "trapper"}

--- a/tools/apply_erebor_equipment_sweep.py
+++ b/tools/apply_erebor_equipment_sweep.py
@@ -48,14 +48,16 @@ import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+from _gamedir import game_dir
+
 BOM = b"\xef\xbb\xbf"
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TROOPS = os.path.join(REPO, "Main", "_Module", "ModuleData", "troops", "troops_erebor.xml")
 MODULEDATA = os.path.join(REPO, "Main", "_Module", "ModuleData")
 ARMORY = (
-    r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord/Modules"
-    r"/LOTRLOME_Armory/ModuleData/LOTRLOME_items"
+    game_dir(r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord")
+    + r"/Modules/LOTRLOME_Armory/ModuleData/LOTRLOME_items"
 )
 
 DWARF_CULTURE = "Culture.erebor"

--- a/tools/assign_orc_village_types.py
+++ b/tools/assign_orc_village_types.py
@@ -17,10 +17,13 @@ Usage:
   python tools/assign_orc_village_types.py            # dry-run (prints plan)
   python tools/assign_orc_village_types.py --apply    # writes live file (+ backup)
 """
-import argparse, re, shutil
+import argparse, os, re, shutil
 from datetime import datetime
 
-LIVE = r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord/Modules/TAOM_Map/ModuleData/settlements.xml"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
+LIVE = GAME + r"/Modules/TAOM_Map/ModuleData/settlements.xml"
 ORC_CULTURES = {"goblin", "mistymountainorcs"}  # bluecraig villages (culture goblin) covered when added
 # v1.4.5 VillageType stringIds are CODE-registered in DefaultVillageTypes (NOT XML) — verify against the
 # engine, never a plausible name. "cattle_range" does NOT exist (it's "cattle_farm"); using an unregistered

--- a/tools/assign_orc_village_types.py
+++ b/tools/assign_orc_village_types.py
@@ -17,12 +17,13 @@ Usage:
   python tools/assign_orc_village_types.py            # dry-run (prints plan)
   python tools/assign_orc_village_types.py --apply    # writes live file (+ backup)
 """
-import argparse, os, re, shutil
+import argparse, re, shutil
 from datetime import datetime
+from _gamedir import game_dir
 
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
+GAME = game_dir(r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord")
 LIVE = GAME + r"/Modules/TAOM_Map/ModuleData/settlements.xml"
 ORC_CULTURES = {"goblin", "mistymountainorcs"}  # bluecraig villages (culture goblin) covered when added
 # v1.4.5 VillageType stringIds are CODE-registered in DefaultVillageTypes (NOT XML) — verify against the

--- a/tools/audit_battle_scenes.py
+++ b/tools/audit_battle_scenes.py
@@ -7,16 +7,13 @@ exists on disk (v1.4.5 removed/renamed it), a FIELD BATTLE on a cell with that i
 crashes. Also checks map_indices coverage 0-255 (an uncovered index = no battle scene).
 """
 from __future__ import annotations
-import os
 import re
 from pathlib import Path
+from _gamedir import game_dir
 
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = Path(os.environ.get(
-    "BANNERLORD_GAME_DIR",
-    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
-))
+GAME = Path(game_dir(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"))
 MODULES = GAME / "Modules"
 FILES = {
     "TAOM": MODULES / "TAOM" / "ModuleData" / "sp_battle_scenes.xml",

--- a/tools/audit_item_refs.py
+++ b/tools/audit_item_refs.py
@@ -14,7 +14,7 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-from _gamedir import game_dir
+from _gamedir import ensure_exists, game_dir
 
 ROOT = Path(__file__).resolve().parent.parent
 TAOM_MODULEDATA = ROOT / "Main/_Module/ModuleData"
@@ -88,6 +88,14 @@ def main():
     ap.add_argument("--limit", type=int, default=40,
                     help="Max broken refs to print (default 40; --limit 0 = all)")
     args = ap.parse_args()
+
+    # Nine of the ten registry roots hang off GAME_MODULES; the tenth is TAOM's
+    # own ModuleData in the repo. With the root wrong they are each skipped with
+    # a notice, only TAOM-authored items get registered, and every reference to
+    # a vanilla or Armory item is then reported broken — 35,443 sites against a
+    # true count of 0, at exit 0. The inverse of #404 point 4: not a clean result
+    # that hides a wrong root, a catastrophic one invented by it.
+    ensure_exists(GAME_MODULES, what="the Bannerlord Modules folder")
 
     print("Building v1.4.5 item registry from modules...", file=sys.stderr)
     defined = collect_defined_ids(ITEM_REGISTRY_ROOTS)

--- a/tools/audit_item_refs.py
+++ b/tools/audit_item_refs.py
@@ -14,10 +14,12 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+from _gamedir import game_dir
+
 ROOT = Path(__file__).resolve().parent.parent
 TAOM_MODULEDATA = ROOT / "Main/_Module/ModuleData"
 
-GAME_MODULES = Path("E:/Steam/steamapps/common/Mount & Blade II Bannerlord/Modules")
+GAME_MODULES = Path(game_dir("E:/Steam/steamapps/common/Mount & Blade II Bannerlord")) / "Modules"
 
 # Modules whose Item XMLs build the runtime registry. TAOM's own XMLs are
 # included so TAOM-authored items count as valid.

--- a/tools/audit_mount_parity.py
+++ b/tools/audit_mount_parity.py
@@ -22,13 +22,11 @@ import xml.etree.ElementTree as ET
 from collections import OrderedDict
 
 from tpac_clipinfo import parse as parse_clip
+from _gamedir import game_dir
 
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = os.path.join(os.environ.get(
-    "BANNERLORD_GAME_DIR",
-    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
-), "Modules")
+GAME = os.path.join(game_dir(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"), "Modules")
 LOTR = GAME + r"\LOTRLOME_Armory\ModuleData"
 WARG = GAME + r"\Alliance.Wargs\ModuleData"
 NATIVE = GAME + r"\Native\ModuleData"

--- a/tools/audit_scene_names.py
+++ b/tools/audit_scene_names.py
@@ -13,16 +13,13 @@ Outputs:
   4. Vanilla-vs-TAOM diff (scenes TAOM uses that vanilla doesn't, and vice versa).
 """
 from __future__ import annotations
-import os
 import re
 from pathlib import Path
+from _gamedir import game_dir
 
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = Path(os.environ.get(
-    "BANNERLORD_GAME_DIR",
-    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
-))
+GAME = Path(game_dir(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"))
 MODULES = GAME / "Modules"
 
 SETTLEMENT_FILES = {

--- a/tools/clan_registry.py
+++ b/tools/clan_registry.py
@@ -18,10 +18,13 @@ import os
 import re
 import xml.etree.ElementTree as ET
 
+from _gamedir import game_dir
+
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 CLANS_XML = os.path.join(ROOT, "Main", "_Module", "ModuleData", "characters", "clans.xml")
 SPCLANS_XSLT = os.path.join(ROOT, "Main", "_Module", "ModuleData", "spclans.xslt")
-VANILLA_SPCLANS = r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord/Modules/SandBox/ModuleData/spclans.xml"
+VANILLA_SPCLANS = (game_dir(r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord")
+                   + r"/Modules/SandBox/ModuleData/spclans.xml")
 
 ATTRS = ("culture", "super_faction", "color", "color2", "default_party_template",
          "is_bandit", "is_minor_faction", "is_clan_type_mercenary", "is_outlaw")

--- a/tools/cleanup_deleted_gondor_armor.py
+++ b/tools/cleanup_deleted_gondor_armor.py
@@ -10,15 +10,16 @@ Usage:
 """
 
 import argparse
-import os
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+from _gamedir import ensure_exists, game_dir
+
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
 # The E:/repos asset-repo entry is a different concept and keeps its own literal.
-GAME = os.environ.get("BANNERLORD_GAME_DIR") or "E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
+GAME = game_dir("E:/Steam/steamapps/common/Mount & Blade II Bannerlord")
 ARMORY_PATHS = [
     Path("E:/repos/lotraom-assets/shared/LOTRLOME_Armory/ModuleData/LOTRLOME_items/gondor"),
     Path(GAME) / "Modules/LOTRLOME_Armory/ModuleData/LOTRLOME_items/gondor",
@@ -188,6 +189,11 @@ def main():
     group.add_argument("--dry-run", action="store_true", help="List items to remove")
     group.add_argument("--apply", action="store_true", help="Remove items from XMLs")
     args = parser.parse_args()
+
+    # With neither location present the loop prints two SKIP lines and a
+    # "Grand total: 0", then exits 0 — indistinguishable from a clean run.
+    if not any(p.exists() for p in ARMORY_PATHS):
+        ensure_exists(ARMORY_PATHS[-1], what="the Gondor item folder")
 
     grand_total = 0
     for armory_base in ARMORY_PATHS:

--- a/tools/cleanup_deleted_gondor_armor.py
+++ b/tools/cleanup_deleted_gondor_armor.py
@@ -10,13 +10,18 @@ Usage:
 """
 
 import argparse
+import os
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+# The E:/repos asset-repo entry is a different concept and keeps its own literal.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or "E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
 ARMORY_PATHS = [
     Path("E:/repos/lotraom-assets/shared/LOTRLOME_Armory/ModuleData/LOTRLOME_items/gondor"),
-    Path("E:/Steam/steamapps/common/Mount & Blade II Bannerlord/Modules/LOTRLOME_Armory/ModuleData/LOTRLOME_items/gondor"),
+    Path(GAME) / "Modules/LOTRLOME_Armory/ModuleData/LOTRLOME_items/gondor",
 ]
 
 # Item IDs to remove, grouped by source XML file

--- a/tools/generate_new_faction_settlements.py
+++ b/tools/generate_new_faction_settlements.py
@@ -22,12 +22,13 @@ from datetime import datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from assign_orc_village_types import fief_types, ORC_CULTURES  # per-fief orc village-type rule
+from _gamedir import game_dir
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 LAYOUT = os.path.join(ROOT, "tools", "taom_new_factions_layout.json")
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
+GAME = game_dir(r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord")
 LIVE = GAME + r"/Modules/TAOM_Map/ModuleData/settlements.xml"
 
 # ---- Curated display names (placeholders, lore-flavoured; user can rename freely) ----

--- a/tools/generate_new_faction_settlements.py
+++ b/tools/generate_new_faction_settlements.py
@@ -25,7 +25,10 @@ from assign_orc_village_types import fief_types, ORC_CULTURES  # per-fief orc vi
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 LAYOUT = os.path.join(ROOT, "tools", "taom_new_factions_layout.json")
-LIVE = r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord/Modules/TAOM_Map/ModuleData/settlements.xml"
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:/Steam/steamapps/common/Mount & Blade II Bannerlord"
+LIVE = GAME + r"/Modules/TAOM_Map/ModuleData/settlements.xml"
 
 # ---- Curated display names (placeholders, lore-flavoured; user can rename freely) ----
 NAMES = {

--- a/tools/native_crash_triage.py
+++ b/tools/native_crash_triage.py
@@ -32,11 +32,10 @@ import os
 import re
 import struct
 import sys
+from _gamedir import game_dir
 
-DEFAULT_DLL = os.environ.get(
-    "BANNERLORD_GAME_DIR",
-    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
-) + r"\bin\Win64_Shipping_Client\TaleWorlds.Native.dll"
+DEFAULT_DLL = (game_dir(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
+               + r"\bin\Win64_Shipping_Client\TaleWorlds.Native.dll")
 
 
 class Pe:

--- a/tools/patch_quad_movement.py
+++ b/tools/patch_quad_movement.py
@@ -10,7 +10,10 @@ Structure (v2 single-item AnimationClip _anm.tpac):
 """
 import struct, os, shutil
 
-DIR = r'E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules\LOTRLOME_Armory\Assets\creature\chariot\animations'
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get('BANNERLORD_GAME_DIR') or r'E:\Steam\steamapps\common\Mount & Blade II Bannerlord'
+DIR = GAME + r'\Modules\LOTRLOME_Armory\Assets\creature\chariot\animations'
 PAIRS = [  # (target, donor) — donor is a tagged sibling of the same gait direction
     ('chariot_gait_walkfast_anm.tpac',     'chariot_walkfast_anm.tpac'),
     ('chariot_gait_walkbackfast_anm.tpac', 'chariot_walkbackfast_anm.tpac'),

--- a/tools/patch_quad_movement.py
+++ b/tools/patch_quad_movement.py
@@ -9,10 +9,11 @@ Structure (v2 single-item AnimationClip _anm.tpac):
   meta tail after the last flag string: [ClipUsages count][len][quad_movement] [empty list count=0] [3 step floats]
 """
 import struct, os, shutil
+from _gamedir import game_dir
 
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = os.environ.get('BANNERLORD_GAME_DIR') or r'E:\Steam\steamapps\common\Mount & Blade II Bannerlord'
+GAME = game_dir(r'E:\Steam\steamapps\common\Mount & Blade II Bannerlord')
 DIR = GAME + r'\Modules\LOTRLOME_Armory\Assets\creature\chariot\animations'
 PAIRS = [  # (target, donor) — donor is a tagged sibling of the same gait direction
     ('chariot_gait_walkfast_anm.tpac',     'chariot_walkfast_anm.tpac'),

--- a/tools/rebuild_translation_files.py
+++ b/tools/rebuild_translation_files.py
@@ -13,13 +13,17 @@ Usage: python tools/rebuild_translation_files.py --lang RU
 
 import argparse
 import json
+import os
 import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-GAME_ROOT = Path(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules")
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+GAME_ROOT = Path(GAME) / "Modules"
 
 LANGUAGES = {
     "BR":  ("por-BR", "Portuguese (Brazilian)"),

--- a/tools/rebuild_translation_files.py
+++ b/tools/rebuild_translation_files.py
@@ -13,17 +13,17 @@ Usage: python tools/rebuild_translation_files.py --lang RU
 
 import argparse
 import json
-import os
 import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+from _gamedir import ensure_exists, game_modules
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
-GAME_ROOT = Path(GAME) / "Modules"
+GAME_ROOT = game_modules(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
 
 LANGUAGES = {
     "BR":  ("por-BR", "Portuguese (Brazilian)"),
@@ -177,6 +177,10 @@ def rebuild_language(lang):
 
     # ─── LOTRLOME_Armory: 19 source XMLs at root of Languages/ ─────────────────
     armory_root = GAME_ROOT / "LOTRLOME_Armory" / "ModuleData" / "Languages"
+    # mkdir(parents=True) under a root that does not exist quietly builds the
+    # whole Modules/LOTRLOME_Armory/ModuleData/Languages/<lang> chain there,
+    # finds no loc_*.xml to read, and the run still ends on "Done." (#404).
+    ensure_exists(armory_root, what="the Armory Languages folder")
     armory_target = armory_root / lang
     armory_target.mkdir(parents=True, exist_ok=True)
     for src_path in sorted(armory_root.glob("loc_*.xml")):

--- a/tools/remap_stale_scene_names.py
+++ b/tools/remap_stale_scene_names.py
@@ -18,10 +18,14 @@ Usage:
 """
 from __future__ import annotations
 import argparse
+import os
 import re
 from pathlib import Path
 
-GAME = Path(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = Path(os.environ.get("BANNERLORD_GAME_DIR")
+            or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
 MODULES = GAME / "Modules"
 LIVE = MODULES / "TAOM_Map" / "ModuleData" / "settlements.xml"
 SHADOW = Path(__file__).resolve().parent.parent / "Main" / "_Module" / "ModuleData" / "settlements.xml"

--- a/tools/remap_stale_scene_names.py
+++ b/tools/remap_stale_scene_names.py
@@ -18,14 +18,14 @@ Usage:
 """
 from __future__ import annotations
 import argparse
-import os
 import re
 from pathlib import Path
 
+from _gamedir import ensure_exists, game_dir
+
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = Path(os.environ.get("BANNERLORD_GAME_DIR")
-            or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
+GAME = Path(game_dir(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"))
 MODULES = GAME / "Modules"
 LIVE = MODULES / "TAOM_Map" / "ModuleData" / "settlements.xml"
 SHADOW = Path(__file__).resolve().parent.parent / "Main" / "_Module" / "ModuleData" / "settlements.xml"
@@ -75,6 +75,11 @@ def main() -> int:
     args = ap.parse_args()
     if not (args.dry_run or args.apply):
         ap.error("pass --dry-run or --apply")
+
+    # A wrong root globs no SceneObj folders and matches no remaps, so the run
+    # ends on "0 of 13 remaps match the live file" and exits 0 — which reads as
+    # "already remapped" rather than "looked in the wrong place".
+    ensure_exists(MODULES, what="the Bannerlord Modules folder")
 
     folders = scene_folders_lower()
     # Only require a replacement scene to exist for entries that ACTUALLY match the

--- a/tools/rollback_erebor_iron_misfile.py
+++ b/tools/rollback_erebor_iron_misfile.py
@@ -17,10 +17,10 @@ import os
 import re
 import sys
 
-EREBOR_DIR = (
-    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
-    r"\Modules\LOTRLOME_Armory\ModuleData\LOTRLOME_items\erebor"
-)
+# BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
+# The literal stays as the fallback so behaviour is unchanged where it is not set.
+GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+EREBOR_DIR = GAME + r"\Modules\LOTRLOME_Armory\ModuleData\LOTRLOME_items\erebor"
 
 # Section header inserted by generate_erebor_armor.py
 SECTION_RE = re.compile(

--- a/tools/rollback_erebor_iron_misfile.py
+++ b/tools/rollback_erebor_iron_misfile.py
@@ -17,9 +17,11 @@ import os
 import re
 import sys
 
+from _gamedir import ensure_exists, game_dir
+
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
-GAME = os.environ.get("BANNERLORD_GAME_DIR") or r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+GAME = game_dir(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
 EREBOR_DIR = GAME + r"\Modules\LOTRLOME_Armory\ModuleData\LOTRLOME_items\erebor"
 
 # Section header inserted by generate_erebor_armor.py
@@ -74,6 +76,9 @@ def main():
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--apply", action="store_true")
     args = parser.parse_args()
+    # Without this, a wrong root prints five "SKIP: <file> not found" lines,
+    # "Total removed: 0" and exits 0 — which reads as "nothing to roll back".
+    ensure_exists(EREBOR_DIR, what="the Erebor item folder")
     if args.dry_run:
         rollback(dry_run=True)
     elif args.apply:

--- a/tools/taom_mcp_server.py
+++ b/tools/taom_mcp_server.py
@@ -27,15 +27,17 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import taom_schema as ts
 import taom_query as tq
+from _gamedir import game_modules
 from mcp.server.fastmcp import FastMCP
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MODULEDATA = REPO_ROOT / "Main" / "_Module" / "ModuleData"
 SCHEMA_DIR = Path(__file__).resolve().parent / "schemas"
-GAME_MODULES = Path(
-    os.environ.get("BANNERLORD_GAME_MODULES",
-                   r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules")
-)
+# $BANNERLORD_GAME_MODULES still wins when set, but the folder is otherwise
+# derived from $BANNERLORD_GAME_DIR like every other tool: setting the install
+# root correctly and still having this server answer against the old install is
+# the trap #404 removes.
+GAME_MODULES = game_modules(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
 
 
 def _build_query() -> tq.ModuleDataQuery:

--- a/tools/tests/test_gamedir.py
+++ b/tools/tests/test_gamedir.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Tests for tools/_gamedir.py — the one place that answers "where is the install".
+
+Run:  python -m unittest discover -s tools/tests -p "test_*.py"
+
+The cases that matter are the ones a plain os.environ.get(VAR, default) gets
+wrong: an exported-but-blank variable, and a root that is not there. Both were
+reported in issue #404 as producing a clean-looking result rather than saying
+the root is wrong.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import _gamedir  # noqa: E402
+
+DEFAULT = r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
+
+
+class _EnvIsolated(unittest.TestCase):
+    """Each test gets the variable in a known state and restores it after."""
+
+    def setUp(self):
+        self._saved = os.environ.get(_gamedir.ENV_VAR)
+        os.environ.pop(_gamedir.ENV_VAR, None)
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop(_gamedir.ENV_VAR, None)
+        else:
+            os.environ[_gamedir.ENV_VAR] = self._saved
+
+
+class GameDirTests(_EnvIsolated):
+
+    def test_unset_returns_the_literal_unchanged(self):
+        # The whole point of the fallback: behaviour is unchanged off a
+        # configured machine, byte for byte.
+        self.assertEqual(_gamedir.game_dir(DEFAULT), DEFAULT)
+
+    def test_set_returns_the_override(self):
+        os.environ[_gamedir.ENV_VAR] = r"D:\SteamLibrary\Bannerlord"
+        self.assertEqual(_gamedir.game_dir(DEFAULT), r"D:\SteamLibrary\Bannerlord")
+
+    def test_blank_is_treated_as_unset(self):
+        # os.environ.get(VAR, default) returns "" here, and Path("") is "." —
+        # the tool then reports every file missing instead of the root being
+        # wrong. #404 point 4.
+        os.environ[_gamedir.ENV_VAR] = ""
+        self.assertEqual(_gamedir.game_dir(DEFAULT), DEFAULT)
+
+    def test_whitespace_only_is_treated_as_unset(self):
+        os.environ[_gamedir.ENV_VAR] = "   "
+        self.assertEqual(_gamedir.game_dir(DEFAULT), DEFAULT)
+
+    def test_value_is_returned_verbatim(self):
+        # No normalising: callers compose their own paths and several keep a
+        # forward-slash literal, so the separator style they get back is theirs.
+        os.environ[_gamedir.ENV_VAR] = "D:/SteamLibrary/Bannerlord"
+        self.assertEqual(_gamedir.game_dir(DEFAULT), "D:/SteamLibrary/Bannerlord")
+
+
+class EnsureExistsTests(_EnvIsolated):
+
+    def test_returns_a_path_when_the_root_is_there(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(_gamedir.ensure_exists(d), Path(d))
+
+    def test_exits_2_when_the_root_is_absent(self):
+        missing = os.path.join(tempfile.gettempdir(), "taom_no_such_root_404")
+        with self.assertRaises(SystemExit) as ctx:
+            _gamedir.ensure_exists(missing)
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_the_message_names_the_path_and_the_variable(self):
+        missing = os.path.join(tempfile.gettempdir(), "taom_no_such_root_404")
+        import io
+        import contextlib
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err), self.assertRaises(SystemExit):
+            _gamedir.ensure_exists(missing)
+        self.assertIn(missing, err.getvalue())
+        self.assertIn(_gamedir.ENV_VAR, err.getvalue())
+
+    def test_the_message_can_say_what_was_being_looked_for(self):
+        missing = os.path.join(tempfile.gettempdir(), "taom_no_such_root_404")
+        import io
+        import contextlib
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err), self.assertRaises(SystemExit):
+            _gamedir.ensure_exists(missing, what="the Erebor item folder")
+        self.assertIn("the Erebor item folder", err.getvalue())
+
+
+class GameModulesTests(_EnvIsolated):
+    """Precedence for the Modules folder, which taom_mcp_server.py needs.
+
+    BANNERLORD_GAME_MODULES predates BANNERLORD_GAME_DIR and names the Modules
+    folder directly. It stays as an explicit override, but setting only
+    BANNERLORD_GAME_DIR has to be enough for a correct setup — an MCP server
+    answering item_exists against the old install is hard to notice (#404).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._saved_modules = os.environ.get(_gamedir.MODULES_ENV_VAR)
+        os.environ.pop(_gamedir.MODULES_ENV_VAR, None)
+
+    def tearDown(self):
+        if self._saved_modules is None:
+            os.environ.pop(_gamedir.MODULES_ENV_VAR, None)
+        else:
+            os.environ[_gamedir.MODULES_ENV_VAR] = self._saved_modules
+        super().tearDown()
+
+    def test_neither_set_falls_back_to_the_literal(self):
+        self.assertEqual(_gamedir.game_modules(DEFAULT), Path(DEFAULT) / "Modules")
+
+    def test_game_dir_alone_is_enough(self):
+        os.environ[_gamedir.ENV_VAR] = r"D:\SteamLibrary\Bannerlord"
+        self.assertEqual(_gamedir.game_modules(DEFAULT),
+                         Path(r"D:\SteamLibrary\Bannerlord") / "Modules")
+
+    def test_the_modules_override_wins(self):
+        os.environ[_gamedir.ENV_VAR] = r"D:\SteamLibrary\Bannerlord"
+        os.environ[_gamedir.MODULES_ENV_VAR] = r"E:\elsewhere\Modules"
+        self.assertEqual(_gamedir.game_modules(DEFAULT), Path(r"E:\elsewhere\Modules"))
+
+    def test_a_blank_modules_override_defers_to_game_dir(self):
+        os.environ[_gamedir.ENV_VAR] = r"D:\SteamLibrary\Bannerlord"
+        os.environ[_gamedir.MODULES_ENV_VAR] = ""
+        self.assertEqual(_gamedir.game_modules(DEFAULT),
+                         Path(r"D:\SteamLibrary\Bannerlord") / "Modules")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate_all_troop_refs.py
+++ b/tools/validate_all_troop_refs.py
@@ -15,14 +15,12 @@ import re
 import os
 import sys
 import glob
+from _gamedir import game_dir
 
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
 ARMORY_ROOT = os.path.join(
-    os.environ.get(
-        "BANNERLORD_GAME_DIR",
-        r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
-    ),
+    game_dir(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"),
     "Modules", "LOTRLOME_Armory", "ModuleData", "LOTRLOME_items",
 )
 

--- a/tools/validate_all_troop_refs.py
+++ b/tools/validate_all_troop_refs.py
@@ -15,7 +15,7 @@ import re
 import os
 import sys
 import glob
-from _gamedir import game_dir
+from _gamedir import ensure_exists, game_dir
 
 # BANNERLORD_GAME_DIR is the install path README.md requires and setup-dev-env.ps1 sets.
 # The literal stays as the fallback so behaviour is unchanged where it is not set.
@@ -62,6 +62,12 @@ def validate_culture(culture: str, armory_ids: set) -> int:
 
 
 def main():
+    # An absent Armory root collects zero ids, so every armor ref in every
+    # culture is reported missing and the run exits 1 — "1488 armor refs do not
+    # resolve" against a true count of 0. This is the underwear-bug gate, so a
+    # fabricated failure here is as costly as a missed one.
+    ensure_exists(ARMORY_ROOT, what="the LOTRLOME_Armory item folder")
+
     cultures = [
         "gondor", "mordor", "isengard", "dolguldur",
         "gundabad", "erebor", "rhun_new", "dale",

--- a/tools/validate_gondor_refs.py
+++ b/tools/validate_gondor_refs.py
@@ -8,7 +8,7 @@ import os
 import re
 import sys
 import glob
-from _gamedir import game_dir
+from _gamedir import ensure_exists, game_dir
 
 TROOPS_FILE = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -42,6 +42,11 @@ def collect_ids() -> set:
 
 
 def main():
+    # An absent Armory root collects zero ids, so every sk_gd_* / sk_dg_*
+    # reference is reported missing and the run exits 1 predicting the underwear
+    # bug in-game — from a folder it never read.
+    ensure_exists(ARMORY_BASE, what="the Gondor item folder")
+
     refs = collect_refs()
     ids = collect_ids()
     missing = sorted(refs - ids)

--- a/tools/validate_gondor_refs.py
+++ b/tools/validate_gondor_refs.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import glob
+from _gamedir import game_dir
 
 TROOPS_FILE = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -19,10 +20,7 @@ TROOPS_FILE = os.path.join(
 # (tools/.env.example also documents a narrower TAOM_ARMORY_BASE, but only
 # cleanup_deleted_gondor_items.py reads it; the game root is the consistent knob here.)
 ARMORY_BASE = os.path.join(
-    os.environ.get(
-        "BANNERLORD_GAME_DIR",
-        r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
-    ),
+    game_dir(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"),
     "Modules", "LOTRLOME_Armory", "ModuleData", "LOTRLOME_items", "gondor",
 )
 

--- a/tools/validate_moduledata.py
+++ b/tools/validate_moduledata.py
@@ -43,13 +43,18 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import taom_schema as ts
+# Aliased: main() binds a local `game_modules`, which would shadow the import.
+from _gamedir import game_modules as resolve_game_modules
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MODULEDATA = REPO_ROOT / "Main" / "_Module" / "ModuleData"
 SCHEMA_DIR = Path(__file__).resolve().parent / "schemas"
 
-DEFAULT_GAME_MODULES = Path(
-    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord\Modules"
+# The commit hook runs this with no --game-modules, so the default is what it
+# gets. A wrong one left BROKEN_ITEM_REF and BROKEN_TROOP_REF unable to fire
+# while the hook still saw PASS (#404).
+DEFAULT_GAME_MODULES = resolve_game_modules(
+    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord"
 )
 
 
@@ -80,8 +85,10 @@ def main() -> int:
         print(f"WARNING: Bannerlord Modules folder not found: {game_modules}\n"
               f"         item / troop / party-template ref checks will be SKIPPED (need the\n"
               f"         game install for a complete registry). Culture-validity, duplicate-id,\n"
-              f"         civilian-type and enum checks still run. Pass --game-modules <path> to\n"
-              f"         enable the skipped checks.", file=sys.stderr)
+              f"         civilian-type and enum checks still run. Set $BANNERLORD_GAME_DIR or\n"
+              f"         pass --game-modules <path> to enable the skipped checks.\n"
+              f"         This run will exit 2 (bad input), not 0 — a degraded sweep must not\n"
+              f"         report PASS as though it had checked everything.", file=sys.stderr)
 
     schemas = ts.load_schemas(SCHEMA_DIR)
     print(f"Loaded {len(schemas)} schemas:", file=sys.stderr)
@@ -137,6 +144,12 @@ def main() -> int:
     n_warn = sum(1 for i in issues if i.severity is ts.Severity.WARNING)
     if n_err or (args.warnings_as_errors and n_warn):
         return 1
+    if not game_modules.exists():
+        # PASS from a registry with no items and no NPCCharacters means the two
+        # ref sweeps never ran, and the commit hook cannot tell that apart from
+        # a real pass. 2 is bad-input, which the hook already fails open on, so
+        # nothing starts blocking that did not block before.
+        return 2
     return 0
 
 

--- a/tools/verify_mount_assets.py
+++ b/tools/verify_mount_assets.py
@@ -27,11 +27,9 @@ import os
 import re
 import struct
 import sys
+from _gamedir import game_dir
 
-DEFAULT_GAME = os.environ.get(
-    "BANNERLORD_GAME_DIR",
-    r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord",
-)
+DEFAULT_GAME = game_dir(r"E:\Steam\steamapps\common\Mount & Blade II Bannerlord")
 SKELETON_GUID = bytes.fromhex('d5a335c6bbeadd45883eaa57e4196113')
 MAGIC = 0x43415054
 


### PR DESCRIPTION
Finishes #404 on top of #413. **Stacked**: this branch sits on #413's, and a PR to this repo has to
target a branch here, so the diff shows both commits. Only the second one — `feat(tools): one place
answers where the install is, wrong roots say so` — is new. Merge #413 first and this collapses to it.

Covers items 2, 3 and 4, plus the three tools left over from item 1.

## The helper

`tools/_gamedir.py`, with tests in `tools/tests/test_gamedir.py`:

| | |
|---|---|
| `game_dir(default)` | the install root; a set-but-blank variable counts as unset |
| `game_modules(default)` | the Modules folder, with `BANNERLORD_GAME_MODULES` winning when set |
| `ensure_exists(path, what=...)` | exit 2 naming the path, instead of a clean-looking result |

21 tools resolve through it.

**Point 4, the blank variable.** `os.environ.get("BANNERLORD_GAME_DIR", default)` returns `""` for an
exported-but-empty variable, `Path("")` is `.`, and the tool reports every file missing rather than the
root being wrong. Seven tools still carried that shape — the five from #401 plus `native_crash_triage.py`
and `verify_mount_assets.py`, the one the issue names as where it came from. The two tests covering the
case fail against the old shape, which is how I know they test something:

```
FAIL: test_blank_is_treated_as_unset
AssertionError: '' != 'E:\Steam\steamapps\common\Mount & Blade II Bannerlord'
FAIL: test_whitespace_only_is_treated_as_unset
AssertionError: '   ' != 'E:\Steam\steamapps\common\Mount & Blade II Bannerlord'
```

**Point 4, the wrong root.** `ensure_exists` went to four places, each picked because it was measured
ending on a result that reads as clean. All four exited 0 before and exit 2 with the path named now:

| tool | what it printed on a wrong root |
|---|---|
| `rollback_erebor_iron_misfile.py` | five `SKIP: <file> not found`, then `Total removed: 0` |
| `cleanup_deleted_gondor_armor.py` | two `SKIP:` lines, then `Grand total: 0 items to remove` |
| `remap_stale_scene_names.py` | `0 of 13 remaps match the live file` — reads as "already done" |
| `rebuild_translation_files.py` | built the whole `Modules/LOTRLOME_Armory/ModuleData/Languages/<lang>` chain under the bogus root via `mkdir(parents=True)`, found no `loc_*.xml`, ended on `Done.` |

The last one is the shape from your `validate_moduledata.py` comment: not a failure, a coverage gap that
announces success.

**Point 2.** `taom_mcp_server.py` derives its Modules folder from `BANNERLORD_GAME_DIR` and keeps
`BANNERLORD_GAME_MODULES` as the explicit override, so one variable is enough. The precedence lives in
`game_modules()` rather than in the server, because the server's own tests skip without the `mcp` SDK
and I wanted it covered.

**Point 3.** `tools/.env.example` gains `BANNERLORD_GAME_DIR` and `BANNERLORD_GAME_MODULES`.

## Two judgement calls

**Six of #413's ten kept their inline `or` until this pass converted them too.** Two forms inside one
change is the drift the issue's title is about. It also means the second commit touches files the first
one did.

**`dump_settlement_buildings.py`, `rebalance_armor.py` and `rebalance_settlement_prosperity.py` were
left alone.** They already use `os.environ.get(VAR) or default`, so they do not have the blank-variable
defect, and two of them define a local `game_dir()` that the import would shadow. The win would have
been uniformity by itself, paid for with renames in files this work does not otherwise touch.

## Verification

| check | result |
|---|---|
| Python suite | 400 tests, up from 387, green (9 skipped) |
| output with the variable unset | 6 of the ten byte-identical; the 4 that gained `ensure_exists` change as intended |
| phantom directory tree under a bogus root | no longer created |
| real install, MD5 manifest of 515 files | unchanged throughout |


## The inverse of point 4, and the costlier half

The issue frames a wrong root as something that hides behind a clean result. Three reference
validators do the opposite: they build their registry from the install and treat "not defined" as
"broken", so an absent root registers nothing and condemns everything referenced.

| tool | wrong root | true answer |
|---|---|---|
| `audit_item_refs.py` | `Total broken refs: 35443 sites across 2897 item IDs`, exit 0 | `0 sites across 0 item IDs` |
| `validate_all_troop_refs.py` | `FAIL: 1488 armor refs do not resolve`, exit 1 | `PASS` |
| `validate_gondor_refs.py` | `FAIL: missing references will cause underwear bug in-game`, exit 1 | `PASS` |

The two exiting 1 are worse than the one exiting 0: exit 1 asserts the data is broken, and
`validate_all_troop_refs.py` is the underwear-bug gate `tools/README.md` points at — a fabricated
failure there costs as much as a missed one. All three exit 2 naming the folder they could not read
now; output on a correct root is unchanged.

`validate_mesh_refs.py` shares the shape but not the bug: its root is absent on this machine too and
it already exits 2 saying so. It takes `--items` / `--game` rather than the variable, so it stays as
it is.
## An interpreter floor nobody declared

The suite is green on 3.14. On 3.11 it gives 3 errors in `test_translate_batching.SyncMissingIdsTests`,
identically on a pristine checkout of `tools/`, so not from this work — but the cause is worth recording.
`Path.read_text(newline=)` landed in 3.13:

```
$ py -3.11 -c "from pathlib import Path; Path('x.txt').read_text(encoding='utf-8', newline='')"
TypeError: Path.read_text() got an unexpected keyword argument 'newline'
$ py -3.14 -c "from pathlib import Path; Path('x.txt').read_text(encoding='utf-8', newline='')"   # fine
```

Four tools use the same keyword outside the tests — `generate_lord_template_equipment.py` and two under
`oneoff/` — so the real floor for parts of `tools/` is 3.13, while the docs say 3.9+, 3.10+ and 3.11+ in
different places. Nothing here depends on it either way; flagging it because "3 errors" reads as breakage
when it is an undeclared interpreter floor.

`tools/README.md`'s paragraph on the variable was stale in four ways once #413 and this landed — the tool
count, `.env.example`'s coverage, the MCP server, and the thirteen. Updated with counted numbers.

