### PR TITLE
fix(tools): the GameModel catalogues drifted, and nothing could say so

### DIFF
--- a/.claude/rules/gamemodels.md
+++ b/.claude/rules/gamemodels.md
@@ -6,7 +6,7 @@ paths:
 
 # GameModel Override Rules
 
-TAOM has 34 GameModel overrides. All follow the same pattern.
+TAOM has 47 GameModel overrides. All follow the same pattern.
 
 ## Pattern
 
@@ -59,10 +59,22 @@ protected override void OnGameStart(Game game, IGameStarter gameStarter)
 }
 ```
 
-## Existing Overrides (34 total)
+## Existing Overrides (47 total)
 
 | Model | Base | Feature |
 |-------|------|---------|
+| `TaomAgentStatCalculateModel` | `SandboxAgentStatCalculateModel` (SandBox) | `CareerSystem` |
+| `TaomClanTierModel` | `DefaultClanTierModel` | `CareerSystem` |
+| `TaomInventoryCapacityModel` | `DefaultInventoryCapacityModel` | `CareerSystem` |
+| `TaomMapVisibilityModel` | `DefaultMapVisibilityModel` | `CareerSystem` |
+| `TaomBanditDensityModel` | `DefaultBanditDensityModel` | `BanditManagement` |
+| `TaomNotableSpawnModel` | `DefaultNotableSpawnModel` | `CulturalFeats` |
+| `TaomMarriageModel` | `DefaultMarriageModel` | `NazgulFamily` |
+| `TaomSettlementEconomyModel` | `DefaultSettlementEconomyModel` | `SettlementEconomy` |
+| `TaomSettlementFoodModel` | `DefaultSettlementFoodModel` | `SettlementFood` |
+| `TaomSiegeEventModel` | `DefaultSiegeEventModel` | `Siege` |
+| `TaomTargetScoreModel` | `DefaultTargetScoreCalculatingModel` | `ArmyTargeting` |
+| `TaomPartyNavigationModel` | `DefaultPartyNavigationModel` | `NavalTravel` — **not registered**; the `AddModel` call in `SubModule.cs` is commented out, so these overrides do not run |
 | `TaomCharacterStatsModel` | `DefaultCharacterStatsModel` | `TroopProgression` |
 | `TaomPartyWageModel` | `DefaultPartyWageModel` | `CulturalFeats` |
 | `TaomVolunteerModel` | `DefaultVolunteerModel` | `TroopProgression` |

--- a/docs/reference/gamemodel-registry.md
+++ b/docs/reference/gamemodel-registry.md
@@ -5,6 +5,12 @@
 
 | GameModel | Overrides | Purpose |
 |-----------|-----------|---------|
+| `TaomAgentStatCalculateModel` | `SandboxAgentStatCalculateModel` (SandBox) | Career passives on effective max health and agent stats + the mount-lock gate: elephant, spider and Mumakil monsters are never rideable (`CanAgentRideMount` returns false before `base`). The Rhun war chariot is deliberately EXEMPT — remountable mid-battle, gated only by the item's riding difficulty (#279) |
+| `TaomClanTierModel` | `DefaultClanTierModel` | Career `CompanionLimit` passive applied on top of the vanilla clan-tier limit |
+| `TaomInventoryCapacityModel` | `DefaultInventoryCapacityModel` | Career `InventoryCapacity` passive applied on top of the vanilla capacity |
+| `TaomMapVisibilityModel` | `DefaultMapVisibilityModel` | Career `PartySpottingRange` passive, plus the StealthBonus ratio for how easily OTHERS spot the party (a lower ratio is better) |
+| `TaomBanditDensityModel` | `DefaultBanditDensityModel` | Player-progress-scaled hideout and bandit-party counts (BanditManagement). Every property returns `base` verbatim when scaling is disabled |
+| `TaomNotableSpawnModel` | `DefaultNotableSpawnModel` | Culture notable-count feats applied to `GetTargetNotableCountForSettlement`; falls through to `base` when the settlement has no notables of that occupation |
 | `TaomCharacterStatsModel` | `DefaultCharacterStatsModel` | `MaxCharacterTier => 10` (vanilla 6) + career `Health` passive on `MaxHitpoints` — the ONLY campaign-side consumer of that pip (character screen, `Hero.MaxHitPoints`, daily heal cap), and via `SandboxAgentStatCalculateModel`'s hero branch it feeds in-battle health too, so nothing else may add `Health` (#394) |
 | `TaomPartyWageModel` | `DefaultPartyWageModel` | Extended tier wages (T0-T10) + culture wage/garrison/Rohan mounted feats + career TroopWages passive |
 | `TaomVolunteerModel` | `DefaultVolunteerModel` | `MaxVolunteerTier => 6` (vanilla 4) + alignment-gated recruitment (`MaximumIndexHeroCanRecruitFromHero` returns -1 to block recruiting at an enemy-aligned settlement — AlignmentRecruitment feature) |

--- a/tools/lint_docs.py
+++ b/tools/lint_docs.py
@@ -160,6 +160,7 @@ class LintReport:
     config_drift: list[tuple[Path, int, str, str]] = field(default_factory=list)
     version_mismatches: list[tuple[Path, int, str, str]] = field(default_factory=list)
     budget: list[tuple[Path, int, str, str]] = field(default_factory=list)
+    model_registry: list[tuple[Path, int, str, str]] = field(default_factory=list)
 
     @property
     def total(self) -> int:
@@ -171,6 +172,7 @@ class LintReport:
             + len(self.config_drift)
             + len(self.version_mismatches)
             + len(self.budget)
+            + len(self.model_registry)
         )
 
 
@@ -593,6 +595,91 @@ def check_claude_md_budget() -> list[tuple[Path, int, str, str]]:
     return findings
 
 
+# --------------------------------------------------------------------------- model registry
+#
+# Two files catalogue TAOM's GameModel overrides, and neither is ordinary documentation.
+# `.claude/rules/gamemodels.md` carries `paths: Main/Features/**/Models/*.cs`, so it is loaded
+# automatically whenever a model is edited — its table IS the briefing the next person gets,
+# including the cross-entity-propagation rule written after the NavalTravel #296 RCA. A model
+# missing from it is a model that rule never reaches. `docs/reference/gamemodel-registry.md`
+# opens with "Every TAOM GameModel override", which is a claim a checker can hold it to.
+#
+# Both directions matter, and so does the count in the prose: a hardcoded "TAOM has N overrides"
+# is exactly the shape that rots, and it rots silently because nobody recounts 40 table rows.
+
+MODEL_RULES_DOC = REPO_ROOT / ".claude" / "rules" / "gamemodels.md"
+MODEL_REGISTRY_DOC = DOCS_DIR / "reference" / "gamemodel-registry.md"
+MODELS_SEARCH_ROOT = REPO_ROOT / "Main"
+
+# A TAOM model is a class named Taom*Model deriving from something whose name ends in Model —
+# Default*, Sandbox*, or one of TAOM's own abstract intermediates.
+MODEL_CLASS_RE = re.compile(
+    r"^[ \t]*(?:public\s+|internal\s+)?(?:sealed\s+|abstract\s+|partial\s+)*"
+    r"class\s+(Taom\w*Model)\s*:\s*(\w*Model)\b", re.M)
+MODEL_MENTION_RE = re.compile(r"`(Taom\w*Model)`")
+MODEL_COUNT_CLAIM_RES = (
+    re.compile(r"TAOM has (\d+) GameModel overrides"),
+    re.compile(r"Existing Overrides \((\d+) total\)"),
+)
+
+
+def discover_model_classes() -> dict[str, Path]:
+    """Every Taom*Model in Main/, mapped to the file that declares it."""
+    found: dict[str, Path] = {}
+    if not MODELS_SEARCH_ROOT.is_dir():
+        return found
+    for path in MODELS_SEARCH_ROOT.rglob("*.cs"):
+        parts = set(path.parts)
+        if "obj" in parts or "bin" in parts:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for name, _base in MODEL_CLASS_RE.findall(text):
+            found.setdefault(name, path)
+    return found
+
+
+def _line_of(text: str, needle: str) -> int:
+    idx = text.find(needle)
+    return text.count("\n", 0, idx) + 1 if idx >= 0 else 0
+
+
+def check_model_registry() -> list[tuple[Path, int, str, str]]:
+    findings: list[tuple[Path, int, str, str]] = []
+    in_code = discover_model_classes()
+    if not in_code:
+        # No models found at all means the search root moved, not that the catalogues are clean.
+        # Staying silent here would turn a broken checker into a green one.
+        findings.append((MODELS_SEARCH_ROOT, 0, "no-models",
+                         f"found no Taom*Model classes under {rel(MODELS_SEARCH_ROOT)} — "
+                         "the search root moved, so this check cannot vouch for anything"))
+        return findings
+
+    for doc in (MODEL_RULES_DOC, MODEL_REGISTRY_DOC):
+        if not doc.is_file():
+            findings.append((doc, 0, "missing-doc", f"{rel(doc)} does not exist"))
+            continue
+        text = doc.read_text(encoding="utf-8", errors="replace")
+        listed = set(MODEL_MENTION_RE.findall(text))
+
+        for name in sorted(set(in_code) - listed):
+            findings.append((doc, 0, "unlisted-model",
+                             f"`{name}` ({rel(in_code[name])}) is not in {rel(doc)}"))
+        for name in sorted(listed - set(in_code)):
+            findings.append((doc, _line_of(text, f"`{name}`"), "phantom-model",
+                             f"`{name}` is listed in {rel(doc)} but no such class exists"))
+
+        for pattern in MODEL_COUNT_CLAIM_RES:
+            for m in pattern.finditer(text):
+                claimed = int(m.group(1))
+                if claimed != len(in_code):
+                    findings.append((doc, text.count("\n", 0, m.start()) + 1, "model-count",
+                                     f"claims {claimed} GameModel overrides; {len(in_code)} exist"))
+    return findings
+
+
 def rel(p: Path) -> str:
     try:
         return str(p.relative_to(REPO_ROOT)).replace("\\", "/")
@@ -612,6 +699,7 @@ def format_report(report: LintReport, quick: bool) -> str:
         out.append(f"- Config-example drift (doc JSON != shipped ModuleData config): **{len(report.config_drift)}**")
         out.append(f"- Version mismatches (CLAUDE.md / snapshot != pin): **{len(report.version_mismatches)}**")
         out.append(f"- CLAUDE.md budget (size/row/line caps{'' if CLAUDE_MD_BUDGET_ENFORCE else ', warn-only'}): **{len(report.budget)}**")
+        out.append(f"- GameModel registry drift (code vs the two catalogues): **{len(report.model_registry)}**")
     out.append("")
     if report.dead_links:
         out.append("## Dead links")
@@ -673,6 +761,18 @@ def format_report(report: LintReport, quick: bool) -> str:
                 loc = f"`{rel(f)}:{lineno}`" if lineno else f"`{rel(f)}`"
                 out.append(f"- {loc} — [{kind}] {msg}")
             out.append("")
+        if report.model_registry:
+            out.append("## GameModel registry drift")
+            out.append("")
+            out.append("`.claude/rules/gamemodels.md` is `paths:`-scoped to the model files, so it is the "
+                       "briefing whoever edits a model actually receives — a model missing from its table "
+                       "never gets the cross-entity-propagation rule. `docs/reference/gamemodel-registry.md` "
+                       "claims to list every override. Add the model to both, or correct the claim.")
+            out.append("")
+            for f, lineno, kind, msg in report.model_registry:
+                loc = f"`{rel(f)}:{lineno}`" if lineno else f"`{rel(f)}`"
+                out.append(f"- {loc} — [{kind}] {msg}")
+            out.append("")
     if report.total == 0:
         out.append("**Clean — no findings.**")
         out.append("")
@@ -709,6 +809,7 @@ def main(argv: list[str]) -> int:
         report.config_drift = check_config_example_drift(files)
         report.version_mismatches = check_version_consistency()
         report.budget = check_claude_md_budget()
+        report.model_registry = check_model_registry()
 
     if args.summary:
         # Structured grep-friendly block, modeled on autoresearch's train.py final output
@@ -721,6 +822,7 @@ def main(argv: list[str]) -> int:
             f"config_drift:      {len(report.config_drift)}",
             f"version_mismatch:  {len(report.version_mismatches)}",
             f"claude_budget:     {len(report.budget)}",
+            f"model_registry:    {len(report.model_registry)}",
             f"total_findings:    {report.total}",
             "---",
             "",

--- a/tools/tests/test_model_registry.py
+++ b/tools/tests/test_model_registry.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Unit tests for the GameModel registry check (tools/lint_docs.py check_model_registry).
+
+Run:  python -m unittest discover -s tools/tests -p "test_*.py"
+  or:  python tools/tests/test_model_registry.py
+
+Two catalogues list TAOM's GameModel overrides and neither is ordinary documentation:
+`.claude/rules/gamemodels.md` is `paths:`-scoped to the model files, so its table is the
+briefing whoever edits a model receives; `docs/reference/gamemodel-registry.md` opens with
+"Every TAOM GameModel override". Both had drifted (12 and 6 models missing, a count claiming
+34 against 47 real classes) and nothing said so.
+
+Every test here builds a SYNTHETIC tree in a tempdir and repoints lint_docs's roots at it,
+following test_lint_docs.py. Each guard is exercised in BOTH directions — a clean tree that
+must stay silent AND a broken tree that must speak — because a check that has only ever been
+seen passing is not known to be able to fail.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import lint_docs as ld  # noqa: E402
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class _SyntheticRepo(unittest.TestCase):
+    """A tree with two model classes and two catalogues, both correct by default."""
+
+    MODELS = ("TaomFooModel", "TaomBarModel")
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self._saved = (ld.REPO_ROOT, ld.DOCS_DIR, ld.MODEL_RULES_DOC,
+                       ld.MODEL_REGISTRY_DOC, ld.MODELS_SEARCH_ROOT)
+
+        ld.REPO_ROOT = self.root
+        ld.DOCS_DIR = self.root / "docs"
+        ld.MODEL_RULES_DOC = self.root / ".claude" / "rules" / "gamemodels.md"
+        ld.MODEL_REGISTRY_DOC = self.root / "docs" / "reference" / "gamemodel-registry.md"
+        ld.MODELS_SEARCH_ROOT = self.root / "Main"
+
+        _write(self.root / "Main" / "Features" / "Foo" / "Models" / "TaomFooModel.cs",
+               "namespace TAOM;\npublic class TaomFooModel : DefaultFooModel\n{\n}\n")
+        _write(self.root / "Main" / "Features" / "Bar" / "Models" / "TaomBarModel.cs",
+               "namespace TAOM;\npublic class TaomBarModel : DefaultBarModel\n{\n}\n")
+        self.write_catalogues(self.MODELS, count=2)
+
+    def tearDown(self):
+        (ld.REPO_ROOT, ld.DOCS_DIR, ld.MODEL_RULES_DOC,
+         ld.MODEL_REGISTRY_DOC, ld.MODELS_SEARCH_ROOT) = self._saved
+        self._tmp.cleanup()
+
+    def write_catalogues(self, names, count=None):
+        rows = "\n".join(f"| `{n}` | `Default` | `Feature` |" for n in names)
+        header = f"TAOM has {count} GameModel overrides.\n\n" if count is not None else ""
+        _write(ld.MODEL_RULES_DOC, f"---\npaths:\n  - \"Main/**\"\n---\n\n{header}{rows}\n")
+        _write(ld.MODEL_REGISTRY_DOC, f"> Every TAOM GameModel override.\n\n{rows}\n")
+
+    def kinds(self):
+        return [k for _f, _l, k, _m in ld.check_model_registry()]
+
+
+class CleanTree(_SyntheticRepo):
+    def test_a_correct_tree_reports_nothing(self):
+        # The negative half of every test below: without this, a check that always fired
+        # would still make them all pass.
+        self.assertEqual([], ld.check_model_registry())
+
+    def test_both_models_are_discovered(self):
+        self.assertEqual(set(self.MODELS), set(ld.discover_model_classes()))
+
+    def test_obj_and_bin_copies_are_not_discovered(self):
+        # Main/obj and Main/bin hold compiler copies of the same sources; counting them
+        # would double every model and make the count claim permanently wrong.
+        _write(self.root / "Main" / "obj" / "Debug" / "TaomGhostModel.cs",
+               "public class TaomGhostModel : DefaultGhostModel { }\n")
+        _write(self.root / "Main" / "bin" / "Debug" / "TaomSpectreModel.cs",
+               "public class TaomSpectreModel : DefaultSpectreModel { }\n")
+        self.assertEqual(set(self.MODELS), set(ld.discover_model_classes()))
+
+
+class Drift(_SyntheticRepo):
+    def test_a_model_missing_from_the_catalogues_is_reported(self):
+        self.write_catalogues(["TaomFooModel"], count=2)   # TaomBarModel dropped from both
+        kinds = self.kinds()
+        self.assertEqual(2, kinds.count("unlisted-model"), "expected one per catalogue")
+        self.assertTrue(any("TaomBarModel" in m for _f, _l, k, m in ld.check_model_registry()
+                            if k == "unlisted-model"))
+
+    def test_a_catalogue_entry_with_no_class_is_reported(self):
+        # The other direction of rot: a model gets renamed or deleted and its row stays,
+        # reading as though someone still maintains it.
+        self.write_catalogues(list(self.MODELS) + ["TaomDeletedModel"], count=2)
+        self.assertEqual(2, self.kinds().count("phantom-model"))
+
+    def test_a_stale_count_claim_is_reported(self):
+        self.write_catalogues(self.MODELS, count=34)
+        counts = [m for _f, _l, k, m in ld.check_model_registry() if k == "model-count"]
+        self.assertEqual(1, len(counts), "only the rules doc carries a count claim")
+        self.assertIn("claims 34", counts[0])
+        self.assertIn("2 exist", counts[0])
+
+    def test_the_second_count_shape_is_also_checked(self):
+        # ".claude/rules/gamemodels.md" states its total twice, in two different sentences.
+        # Catching only the first would leave the table heading permanently wrong.
+        _write(ld.MODEL_RULES_DOC, "## Existing Overrides (34 total)\n\n"
+               + "\n".join(f"| `{n}` |" for n in self.MODELS) + "\n")
+        self.assertEqual(1, self.kinds().count("model-count"))
+
+    def test_a_correct_count_is_silent(self):
+        self.write_catalogues(self.MODELS, count=2)
+        self.assertEqual(0, self.kinds().count("model-count"))
+
+    def test_a_missing_catalogue_is_reported(self):
+        ld.MODEL_REGISTRY_DOC.unlink()
+        self.assertEqual(1, self.kinds().count("missing-doc"))
+
+    def test_an_empty_search_root_is_reported_rather_than_passing(self):
+        # The failure that would matter most: if Main/ moves, "no models found" must not
+        # read as "every model is catalogued".
+        ld.MODELS_SEARCH_ROOT = self.root / "NoSuchDirectory"
+        kinds = self.kinds()
+        self.assertEqual(["no-models"], kinds)
+
+
+class RealRepo(unittest.TestCase):
+    def test_the_real_catalogues_are_in_sync(self):
+        # Regression pin. This is the check that fires when someone adds a model without
+        # cataloguing it — the whole point of the check existing.
+        findings = ld.check_model_registry()
+        self.assertEqual([], findings,
+                         "GameModel registry drift:\n" + "\n".join(m for *_ , m in findings))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Two files catalogue TAOM's GameModel overrides. **47 classes exist.** `.claude/rules/gamemodels.md`
listed 35 and its prose claimed 34 in two places; `docs/reference/gamemodel-registry.md` listed 41.
Neither had a checker, so neither could be wrong out loud.

This adds `check_model_registry` to `lint_docs.py`, fills in the 12 and 6 missing entries, and
corrects both counts. The tree is at `total_findings: 0`.

## Why the rules file is the one that costs something

It carries `paths: Main/Features/**/Models/*.cs`, so it loads whenever a model is edited — that
table *is* the briefing the next person gets, together with rule 9, the cross-entity-propagation
rule written after the NavalTravel #296 RCA.

`TaomMapVisibilityModel` returns a per-party spotting range. That is precisely the shape rule 9
exists for — a per-entity value the engine recomputes across a group. It was not in the table, so
the rule written for it never reached it. Same for `TaomBanditDensityModel`, `TaomClanTierModel`,
`TaomInventoryCapacityModel`, `TaomNotableSpawnModel` and `TaomAgentStatCalculateModel`, which were
in neither file.

`docs/reference/gamemodel-registry.md` opens with "Every TAOM GameModel override", which is a claim
a checker can hold it to. Now one does.

## What the check reports

| kind | fires when |
|---|---|
| `unlisted-model` | a `Taom*Model` in `Main/` is absent from a catalogue |
| `phantom-model` | a catalogue names a class that does not exist — a rename or deletion leaving a row that reads as maintained |
| `model-count` | a prose count disagrees with reality, in either of the two sentences that state it |
| `missing-doc` | a catalogue file is gone |
| `no-models` | the search finds nothing under `Main/` |

That last one is deliberate. If `Main/` ever moves, "found no models" must not read as "every model
is catalogued" — a broken checker that reports clean is worse than no checker. `obj/` and `bin/`
compiler copies are skipped, or every model would be counted twice and the count claim could never
be satisfied.

## Entries added

Six were in neither file — `TaomAgentStatCalculateModel`, `TaomBanditDensityModel`,
`TaomClanTierModel`, `TaomInventoryCapacityModel`, `TaomMapVisibilityModel`, `TaomNotableSpawnModel`
— and go into both, with purposes read off the code rather than inferred from the names.

Six more were already in the registry and missing only from the rules table: `TaomMarriageModel`,
`TaomPartyNavigationModel`, `TaomSettlementEconomyModel`, `TaomSettlementFoodModel`,
`TaomSiegeEventModel`, `TaomTargetScoreModel`.

`TaomPartyNavigationModel` is listed with its state noted rather than silently: its `AddModel` call
in `SubModule.cs:715` is commented out, so its five overrides do not run. A reader comparing the
table against a live session would otherwise be looking for a model that is not there.

## Testing

11 tests in a new `tools/tests/test_model_registry.py` — a separate file rather than additions to
`test_lint_docs.py`, so this cannot collide with #410.

**Every guard verified by breaking what it guards.** A check seen only passing is not known to be
able to fail:

| break applied to the checker | tests |
|---|---|
| stop reporting unlisted models | failed |
| stop reporting phantom entries | failed |
| stop checking the count claim | failed (2) |
| stop skipping `obj/` and `bin/` copies | failed |
| treat an empty search root as clean | failed |
| drop a real model back out of the catalogue | failed |

Green after each restore. Every guard also has a silent counterpart — a correct tree, a correct
count, `obj/` copies present but ignored — because a check that only ever fires is as useless as
one that never does.

```
python tools/lint_docs.py --summary                  # total_findings: 0, model_registry: 0
python tools/lint_docs.py --fail-on-drift ; echo $?   # 0
python -m unittest discover -s tools/tests -p "test_*.py"
```

398 tests, 3 errors — all three in `test_translate_batching`, present before this branch, from
`Path.read_text(newline=…)` needing 3.13.

## Interaction with #410

Both touch `lint_docs.py` in disjoint regions: #410 in the version-pattern and
`check_stale_versions` areas, this at the end of the file plus the report and summary assembly. I
merged the two branches locally to check rather than assume — **no conflicts**, both test files
pass, and the linter reports `stale_versions: 0` and `model_registry: 0` together. Either order
works.

Independent of #414 as well; nothing here touches the co-op interop code.
