### PR TITLE
fix(coopinterop): a fingerprint over zero settings no longer reads as agreement

### DIFF
--- a/Main/Features/CoopInterop/SettingsFingerprint.cs
+++ b/Main/Features/CoopInterop/SettingsFingerprint.cs
@@ -66,6 +66,11 @@ public static class SettingsFingerprint
     {
         if (settingsObjects == null) throw new ArgumentNullException(nameof(settingsObjects));
 
+        // Counted, not merely skipped. A page that could not be read is the difference between
+        // "these two peers agree" and "nothing was compared", and something has to be able to say
+        // which — see FingerprintReport.IsConclusive.
+        var unavailable = settingsObjects.Count(o => o == null);
+
         var relevant = settingsObjects
             .Where(o => o != null)
             .SelectMany(o => o.GetType()
@@ -103,7 +108,8 @@ public static class SettingsFingerprint
         var globalText = string.Concat(groupHashes.OrderBy(kv => kv.Key, StringComparer.Ordinal)
                                                   .Select(kv => kv.Key + ":" + kv.Value + "\n"));
 
-        return new FingerprintReport(Sha256(globalText), groupHashes, counts, relevant.Count);
+        return new FingerprintReport(Sha256(globalText), groupHashes, counts, relevant.Count,
+                                     unavailable);
     }
 
     /// <summary>A property paired with the settings instance it must be read from.</summary>
@@ -207,12 +213,14 @@ public static class SettingsFingerprint
     public sealed class FingerprintReport
     {
         internal FingerprintReport(string global, IReadOnlyDictionary<string, string> byGroup,
-                                   IReadOnlyDictionary<string, int> countsByGroup, int covered)
+                                   IReadOnlyDictionary<string, int> countsByGroup, int covered,
+                                   int unavailable = 0)
         {
             Global = global;
             ByGroup = byGroup;
             CountsByGroup = countsByGroup;
             Covered = covered;
+            Unavailable = unavailable;
         }
 
         public string Global { get; }
@@ -223,12 +231,27 @@ public static class SettingsFingerprint
         /// version bump that silently drops half the settings is visible.</summary>
         public int Covered { get; }
 
+        /// <summary>How many settings pages could not be read at all (a null instance).</summary>
+        public int Unavailable { get; }
+
+        /// <summary>
+        /// False when nothing was measured. SHA-256 of the empty string is a constant, so an
+        /// all-unavailable read produces the same code on every machine — two such peers would
+        /// otherwise compare equal and read it as agreement over 112 settings, when the true
+        /// answer is that neither side was inspected. "Cannot tell" is not "agree".
+        /// </summary>
+        public bool IsConclusive => Covered > 0;
+
         public string ShortGlobal => Global.Substring(0, Math.Min(DisplayLength, Global.Length));
 
         /// <summary>
         /// Groups whose settings differ from <paramref name="other"/>, in name order.
         /// A group present on one side only counts as differing: a peer running a build without
         /// that feature is exactly the mismatch worth reporting.
+        ///
+        /// An empty result means "no group differs", NOT "the two agree" — check
+        /// <see cref="IsConclusive"/> on both sides first, or a pair that measured nothing reads
+        /// as a clean comparison.
         /// </summary>
         public IReadOnlyList<string> DivergentGroups(FingerprintReport other)
         {
@@ -246,7 +269,14 @@ public static class SettingsFingerprint
             return divergent;
         }
 
+        /// <summary>
+        /// True only when both sides actually measured something AND agree. An inconclusive
+        /// report never matches — including against another inconclusive one, which is the pair
+        /// that would otherwise compare equal on an identical empty-string hash.
+        /// </summary>
         public bool Matches(FingerprintReport other) =>
-            other != null && string.Equals(Global, other.Global, StringComparison.Ordinal);
+            other != null
+            && IsConclusive && other.IsConclusive
+            && string.Equals(Global, other.Global, StringComparison.Ordinal);
     }
 }

--- a/Main/Features/CoopInterop/SettingsFingerprintLog.cs
+++ b/Main/Features/CoopInterop/SettingsFingerprintLog.cs
@@ -46,10 +46,31 @@ public static class SettingsFingerprintLog
         try
         {
             var report = SettingsFingerprint.ComputeAcross(settingsObjects);
+
+            // Nothing read means nothing to compare, and the code for "nothing" is the same on
+            // every machine. Saying that plainly matters more than printing a code: two peers
+            // reading an identical e3b0c442… would otherwise conclude their settings agree.
+            if (!report.IsConclusive)
+            {
+                logger.LogWarning(
+                    $"{Tag} could not read any of the {settingsObjects.Length} settings page(s) — " +
+                    "MCM's settings provider was not up when the co-op gate fired. NO fingerprint " +
+                    "was taken: the code below is the hash of an empty read and is identical on " +
+                    "every machine, so a peer showing the same code tells you nothing about " +
+                    "whether your settings agree.");
+                logger.LogWarning($"{Tag} global={report.ShortGlobal} over 0 setting(s) — not a comparison.");
+                return;
+            }
+
+            var partial = report.Unavailable > 0
+                ? $" {report.Unavailable} settings page(s) could not be read, so this is partial."
+                : string.Empty;
+
             logger.LogInfo(
                 $"{Tag} global={report.ShortGlobal} over {report.Covered} simulation-relevant setting(s). " +
                 "Compare this line with the other peer's — a difference means the two campaigns " +
-                "will compute different outcomes, and nothing else will say so.");
+                "will compute different outcomes, and nothing else will say so. A match means " +
+                "these settings agree, not that the two installs are equivalent." + partial);
 
             foreach (var kv in report.ByGroup.OrderBy(k => k.Key, StringComparer.Ordinal))
             {

--- a/TAOM.Tests/Features/CoopInterop/SettingsFingerprintTests.cs
+++ b/TAOM.Tests/Features/CoopInterop/SettingsFingerprintTests.cs
@@ -314,6 +314,63 @@ public class SettingsFingerprintTests
     }
 
     [TestMethod]
+    public void EveryPageUnavailable_IsNotReportedAsAgreement()
+    {
+        // Reachable, not hypothetical. MCM 5.12.1 declares
+        //     public static T? Instance =>
+        //         BaseSettingsProvider.Instance?.GetSettings(...) as T;
+        // — a nullable return, a null-conditional on the provider and an `as` cast, so a page read
+        // before MCM's provider is up yields null rather than throwing. Skipping those nulls leaves
+        // nothing to hash, and SHA-256 of the empty string is a constant: two such peers produce
+        // the SAME code and read it as "we agree".
+        var a = SettingsFingerprint.ComputeAcross(null, null, null, null);
+        var b = SettingsFingerprint.ComputeAcross(null, null, null, null);
+
+        Assert.AreEqual(0, a.Covered, "sanity: nothing was measured");
+        Assert.IsFalse(a.Matches(b),
+            "a fingerprint over zero settings must not answer 'equal' — it measured nothing, " +
+            "and 'cannot tell' is not 'agree'");
+    }
+
+    [TestMethod]
+    public void APartialRead_StaysConclusive_ButCountsWhatItMissed()
+    {
+        // One unreadable page must not disarm the whole report — the settings that WERE read can
+        // still catch a divergence. It must be counted, though, or "partial" reads as "complete".
+        var partial = SettingsFingerprint.ComputeAcross(new TaomSettings(), null, null);
+        var whole = SettingsFingerprint.ComputeAcross(new TaomSettings());
+
+        Assert.IsTrue(partial.IsConclusive, "settings were read; the report stands");
+        Assert.AreEqual(2, partial.Unavailable, "both nulls must be counted");
+        Assert.AreEqual(0, whole.Unavailable);
+        Assert.IsTrue(partial.Matches(whole), "the pages that were read still hash the same");
+    }
+
+    [TestMethod]
+    public void TheLogAdapter_SaysAReadWasPartial()
+    {
+        var log = new RecordingLogger();
+        SettingsFingerprintLog.WriteAcross(log, new TaomSettings(), null, null, null);
+
+        Assert.IsTrue(log.Lines.Any(l => l.Contains("partial")),
+            "a report missing 3 of 4 pages must say so; got: " + string.Join(" | ", log.Lines));
+    }
+
+    [TestMethod]
+    public void TheLogAdapter_SaysSoWhenItMeasuredNothing()
+    {
+        // The line must not promise that comparing it is meaningful when there was nothing to
+        // compare. This is the same rule as the linter's no-models guard: a check that reports
+        // clean without having looked is worse than no check.
+        var log = new RecordingLogger();
+        SettingsFingerprintLog.WriteAcross(log, null, null, null, null);
+
+        Assert.IsTrue(
+            log.Lines.Any(l => l.Contains("could not read") || l.StartsWith("WARN")),
+            "expected the log to say it read no settings; got: " + string.Join(" | ", log.Lines));
+    }
+
+    [TestMethod]
     public void TheRealSettings_HashWithoutThrowing_AndCoverMostOfThem()
     {
         var report = SettingsFingerprint.Compute(new TaomSettings());

--- a/docs/features/coop-interop.md
+++ b/docs/features/coop-interop.md
@@ -333,6 +333,30 @@ to characterise. The existing try/catch around acceptance is containment, not co
   the day it lands. That makes the "compare settings manually" workaround a comparison of a few
   short strings instead of 112 values read off two screens.
 
+  **All four classes are `AttributeGlobalSettings<T>`, and the reasoning above depends on it.**
+  MCM has three scopes, and only one of them travels with a save. Verified against MCM 5.12.1:
+  `MCM.Internal.GameFeatures.PerSaveCampaignBehavior : CampaignBehaviorBase` carries
+  `SyncData<Dictionary<string, string>>("_settings", ref _settings)`, so **PerSave** is in the
+  savegame. **PerCampaign** is not, despite the name — `PerCampaignSettingsContainer` roots at a
+  `PerCampaign` directory, then `GetOrCreateDirectory(RootFolder, GetCurrentCampaignId())`, and
+  loads through `ISettingsFormat.Load(…)`: a per-machine file keyed by campaign id. It would NOT
+  arrive in parity with the host's save — the campaign id matches while the local file may not
+  exist at all, which is worse than global rather than better. TAOM declares neither:
+  the only `AttributePerCampaignSettings` reference in the tree is a reflection target string in
+  `McmSettingsCollector.cs`, which scans third-party mods. So nothing here is save-inherited and
+  nothing arrives guaranteed-equal. **If a PerSave or PerCampaign settings class ever lands in
+  TAOM, this paragraph stops being true and the fingerprint's meaning changes with it** — a
+  PerSave class would be equal by construction and need not be hashed; a PerCampaign one would
+  need hashing more urgently than a global, not less.
+
+  **A matching fingerprint means the MCM settings agree, and nothing wider.** It covers the 112
+  values on the four settings pages. It does not cover the `ModuleData` JSON/XML that several
+  features fall back to when a setting is unset, the `TAOM.Dependencies` flag files
+  (`patchshield-disabled.flag`, `saveshield-swallow-disabled.flag`, `coop-force-active.flag`),
+  or any difference outside TAOM. None of those three flags gates a setting in the 112 — each
+  governs a Dependencies-side shield with no MCM property — but the general point holds: read the
+  log line as "our settings pages match", not as "our installs are equivalent".
+
   **Still not done:** peers do not exchange them. Putting the fingerprint in save metadata and
   comparing on join is the remaining step, and it cannot be verified without two machines in a
   session — `FingerprintReport.DivergentGroups` is already there for it. BannerlordCoop still


### PR DESCRIPTION
Follow-up to #414, from @Sternab's review. Both code findings there were real; this fixes the one
still open and answers the two doc asks. The `Render` one is already fixed — the merge introduced
`ReadAndRender`, which guards the render as well as the get, plus a `TargetInvocationException`
unwrap so the marker names the cause rather than the reflection wrapper.

## The open one: a fingerprint over zero settings read as agreement

Confirmed exactly as described. With every page unavailable, `.Where(o => o != null)` empties the
set, nothing is hashed, and `Sha256("")` is a constant — `e3b0c44298fc…` on every machine. Two such
peers returned `Matches == true`.

**Reachable, not hypothetical.** MCM 5.12.1 declares

```csharp
public static T? Instance =>
    BaseSettingsProvider.Instance?.GetSettings(GlobalSettings.Cache[typeof(T)]) as T;
```

— a nullable return, a null-conditional on the provider and an `as` cast, so a page read before
MCM's provider is up yields null rather than throwing. Four files in `Main/` already carry a comment
saying the same.

The fix is not to guess values:

- `FingerprintReport.Unavailable` counts pages that could not be read, and `IsConclusive` is false
  when nothing was.
- `Matches` requires both sides to be conclusive. "Cannot tell" is not "agree".
- `WriteAcross` logs a **warning** instead of a code, saying in words that no fingerprint was taken
  and that a peer showing the same code means nothing.
- A partial read still stands — the pages that were read can still catch a divergence — but says
  how many it missed. `ComputeAcross_SkipsNulls` keeps its original intent; only the all-null case
  changes.
- `DivergentGroups` documents that an empty result is "no group differs", not "the two agree".

Falling back to `new TaomSettings()` was considered and rejected, on a count rather than a hunch.
`Main/` has **121** `TaomSettings.Instance?.X ?? …` sites. **88** fall back to a compiled literal;
**33** fall back to a member of a config object instead — `AlignmentDesertionRate ?? _defaults.Rate`,
`CaravanBudgetDiversityFloor ?? Cfg.BudgetFactorFloor` — where the object comes from a config
provider (`AlignmentDesertionSettingsProvider.cs:16` takes `configProvider.GetConfig()`;
`CaravanTradeSettingsProvider.cs:19` resolves `Cfg` the same way). At least one of those providers
reads a file rather than a constant: `AlignmentDesertionConfigProvider` uses `Newtonsoft.Json` to
load `alignment_desertion/alignment_desertion_config.json`. I did not trace the other 32 to their
sources.

So for those 33, hashing `new TaomSettings()` would report 112 settings measured while naming
values that are not necessarily the ones that peer is running. Trading "measured nothing" for
"measured something that may not be what runs" did not look like an improvement — but if you read
that trade the other way, say so and I will make the change.

**One sharp edge, stated rather than left to be found.** `Matches` now returns false for two
different situations — "they differ" and "could not measure". `IsConclusive` exists so a caller can
separate them, and both are documented, but a tri-state would be the honest signature. Nothing in
`Main/` calls `Matches` yet, so it seemed better to leave the shape alone until there is a real
caller to design against. Say the word and it becomes three states.

## Doc ask 1 — MCM scopes

Added, and your reading checks out against MCM 5.12.1:
`MCM.Internal.GameFeatures.PerSaveCampaignBehavior : CampaignBehaviorBase` carries
`SyncData<Dictionary<string, string>>("_settings", ref _settings)`, so PerSave is in the savegame.
`PerCampaignSettingsContainer` roots at a `PerCampaign` directory, then
`GetOrCreateDirectory(RootFolder, GetCurrentCampaignId())`, and loads via `ISettingsFormat.Load(…)`
— a per-machine file keyed by campaign id, which would not arrive in parity with the host's save.
All four TAOM classes are `AttributeGlobalSettings<T>`, and the only `AttributePerCampaignSettings`
in the tree is the reflection target string in `McmSettingsCollector.cs`.

The paragraph says what changes if a PerSave or PerCampaign class ever lands, since that is the
point of writing it down.

## Doc ask 2 — the wider gap, with one correction

The general point is in the docs: a matching fingerprint means the MCM settings agree and nothing
wider — not the `ModuleData` config files behind the 33 fallbacks counted above, not the
`TAOM.Dependencies` flag files, not anything outside TAOM. The log line now ends "A match means
these settings agree, not that the two installs are equivalent."

**But `troopweight-disabled.flag` does not exist**, so it is not in the docs as an example. Checked
six ways before writing anything, because the claim was specific enough to be worth checking:

| check | result |
|---|---|
| the string, case-insensitive, across `Main/ Dependencies/ Stubs/ TAOM.Tests/ plans/ tools/` | zero |
| are flag names built dynamically? | no — three `const string` literals (`PatchShield.cs:36`, `SaveShield.cs:44`, `CoopPresence.cs:47`), so a literal search is sound |
| compiled DLLs, UTF-16 at both alignments, with a control that must find `patchshield-disabled.flag` | `TAOM.dll` carries no `.flag` string at all; `TAOM.Dependencies.dll` carries exactly the three real ones |
| any Harmony patch on `ApplyPartySizeWeightPenalty` | none — interface decl, impl, one call from `TaomPartySizeModel.cs:51`, two comments |
| the one TroopWeight Harmony patch | `[HarmonyPatchCategory("Patch17_TroopWeight")]`, applied at `SubModule.cs:1105`, gated at its own line 24 on `TaomSettings.Instance?.EnableTroopWeight` — the same setting, which **is** in the 112 |
| do any of the three real flags correspond to a setting? | no — `EnablePatchShield`, `EnableSaveShield` and `EnableCoopForce` return zero matches in `TaomSettings.cs` |

The first DLL scan was a false negative twice over — a byte-wise `grep` cannot see .NET's UTF-16
strings, and decoding at one alignment misses every string that starts on an odd offset. Both were
caught by requiring the scan to find a string known to be there; without that control it would have
"proved" the three real flags do not exist either.

One piece of context I can only offer as a fact, not an explanation: `TroopWeightIoC.cs:18` records
that shed-on-upgrade is the only surviving Patch17 hook after the 2026-07-11 rework. TroopWeight's
patch surface used to be larger. Whether that bears on the flag, I have no way to tell.

## Testing

Four tests, each verified able to fail:

| test | how failure was demonstrated |
|---|---|
| all pages unavailable → not agreement | ran against the unfixed code; `Matches` returned true |
| the log says it measured nothing | ran against the unfixed code; got `global=e3b0c44298fc over 0 simulation-relevant setting(s). Compare this line with the other peer's…` |
| a partial read stays conclusive but counts what it missed | broke the `unavailable` counter to a constant 0; failed |
| the log says a read was partial | same break; failed |

`dotnet test TAOM.Tests`: **6092 passed, 1 failed**. The failure is
`OnSessionLaunched_RegistersFiefHubMenuAndOptions`, which I stashed all four files to confirm —
tree at zero modified, so the check could actually fail — and it fails identically on the branch
point with nothing applied. `lint_docs --summary` is `total_findings: 0`.

**Not verified in a running game.** The scenario needs MCM's provider to be down at the co-op gate,
and the line only writes when a co-op module is active, so reproducing it takes a co-op install and
a failure to induce. `coop-interop.md`'s own "Verification status" already lists ten unconfirmed
items — six wanting two machines, four owed by the 2026-08-03 work and none of them run. This adds
an eleventh rather than closing any of them. It should not be read as more tested than it is.
