### PR TITLE
fix(enlistment): no battle command while enlisted

### DIFF
--- a/Main/Features/Enlistment/BattleCommandPolicy.cs
+++ b/Main/Features/Enlistment/BattleCommandPolicy.cs
@@ -1,0 +1,24 @@
+using TAOM.Features.Enlistment.Domain;
+
+namespace TAOM.Features.Enlistment;
+
+/// <summary>
+/// Decides whether the enlisted player's battlefield command must be stripped (#424).
+///
+/// Why this exists: enlistment keeps <c>MobileParty.MainParty.Army</c> permanently null
+/// (<c>ClearArmyAttachment</c> runs in both ParkNear and RestorePresence), and
+/// <c>MapEvent.IsPlayerSergeant()</c> requires <c>Army != null</c> — so it is structurally
+/// false for an enlisted player, and <c>AssignPlayerRoleInTeamMissionController</c> passes
+/// him to <c>Team.SetPlayerRole</c> as the GENERAL of his whole side. A rank-1 private
+/// commands every formation; the lord he serves commands nothing.
+///
+/// The policy is a pure table so the decision is testable without a mission: strip command
+/// exactly when the battle was entered as enlisted service (<see cref="EnlistmentState.EnlistedBattle"/>)
+/// and the player does not lead the battle side. Detached-duty battles are the player's own
+/// business (their duty spawned the fight) and keep vanilla roles.
+/// </summary>
+public static class BattleCommandPolicy
+{
+    public static bool ShouldStripPlayerCommand(EnlistmentState state, bool playerLeadsBattleSide)
+        => state == EnlistmentState.EnlistedBattle && !playerLeadsBattleSide;
+}

--- a/Main/Features/Enlistment/Hooks/EnlistmentBattleRoleMissionBehavior.cs
+++ b/Main/Features/Enlistment/Hooks/EnlistmentBattleRoleMissionBehavior.cs
@@ -1,0 +1,66 @@
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.MountAndBlade;
+using TAOM.Core.Logging;
+
+namespace TAOM.Features.Enlistment.Hooks;
+
+/// <summary>
+/// Strips the enlisted player's battlefield command (#424). Vanilla's
+/// <c>AssignPlayerRoleInTeamMissionController.AfterStart</c> makes him the GENERAL of his
+/// whole side because <c>IsPlayerSergeant()</c> needs <c>Army != null</c> and enlistment
+/// keeps Army permanently null. <c>: MissionLogic</c> — NEVER MissionBehavior
+/// (BehaviorTreeMissionLogic regression rule). Registered UNCONDITIONALLY from SubModule;
+/// all filtering happens inside. SubModule-added behaviors run after the mission's own
+/// controllers, so this AfterStart executes after vanilla's role assignment.
+///
+/// Deliberately <c>SetPlayerRole(false, false)</c> — option (a) from #424 — rather than the
+/// SAS sergeant-score rig, which mutates campaign-level battle leadership
+/// (<c>GetCharacterSergeantScore</c> feeds <c>GetLeaderOfMapEvent</c>). Neither-role is not
+/// a state vanilla produces in campaign; the OOB gate was checked for this
+/// (<c>BattleInitializationModel.CanPlayerSideDeployWithOrderOfBattle</c> reads no player-role
+/// flag), and the in-game F1–F8 observation is tracked on #424.
+/// </summary>
+public class EnlistmentBattleRoleMissionBehavior : MissionLogic
+{
+    private readonly IEnlistmentStateQuery _query;
+    private readonly IModLogger _logger;
+
+    private bool _applied;
+
+    public EnlistmentBattleRoleMissionBehavior(IEnlistmentStateQuery query, IModLogger logger)
+    {
+        _query = query;
+        _logger = logger;
+    }
+
+    public override void AfterStart() => TryStripCommand("AfterStart");
+
+    // Belt for missions with a deployment phase: role flags are re-derived around
+    // deployment, and a second idempotent pass costs nothing when _applied is set.
+    public override void OnDeploymentFinished() => TryStripCommand("DeploymentFinished");
+
+    private void TryStripCommand(string site)
+    {
+        if (_applied || Campaign.Current == null)
+            return;
+
+        var mapEvent = MobileParty.MainParty?.MapEvent;
+        if (mapEvent == null)
+            return;
+
+        var playerLeads = mapEvent.GetLeaderParty(mapEvent.PlayerSide) == PartyBase.MainParty;
+        if (!BattleCommandPolicy.ShouldStripPlayerCommand(_query.State, playerLeads))
+            return;
+
+        var team = Mission?.PlayerTeam;
+        if (team == null)
+            return;
+
+        team.SetPlayerRole(false, false);
+        _applied = true;
+        _logger?.LogInfo(
+            $"[Enlistment] battle command stripped at {site} — enlisted soldier, side led by " +
+            $"'{mapEvent.GetLeaderParty(mapEvent.PlayerSide)?.Id ?? "unknown"}' (#424)");
+    }
+}

--- a/Main/SubModule.cs
+++ b/Main/SubModule.cs
@@ -1398,6 +1398,13 @@ public class SubModule : MBSubModuleBase
             IoC.Resolve<Features.Enlistment.Content.IBattleMeritAccumulator>(),
             IoC.Resolve<Features.Enlistment.Content.IEnlistmentContentStore>(),
             IoC.Resolve<Features.Enlistment.Content.IEnlistmentContentConfigProvider>().GetConfig().MeritScoring));
+        // Registered unconditionally per the same convention; self-filters in AfterStart on
+        // enlisted-battle state. Corrects #424: Army is permanently null while enlisted, so
+        // vanilla's IsPlayerSergeant() is structurally false and AssignPlayerRoleInTeamMissionController
+        // makes the enlisted player GENERAL of his whole side.
+        AddTaomBehavior(new Features.Enlistment.Hooks.EnlistmentBattleRoleMissionBehavior(
+            IoC.Resolve<Features.Enlistment.IEnlistmentStateQuery>(),
+            IoC.Resolve<IModLogger>()));
         // Registered unconditionally; self-filters internally on Campaign.Current and co-op authority.
         AddTaomBehavior(new Features.FieldCommission.Hooks.FieldCommissionMissionLogic());
         // Added unconditionally per TAOM convention; gates internally on

--- a/TAOM.Tests/Features/Enlistment/BattleCommandPolicyTests.cs
+++ b/TAOM.Tests/Features/Enlistment/BattleCommandPolicyTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TAOM.Features.Enlistment;
+using TAOM.Features.Enlistment.Domain;
+
+namespace TAOM.Tests.Features.Enlistment;
+
+/// <summary>
+/// The #424 decision table. Command is stripped exactly when the battle was entered as
+/// enlisted service AND the player does not lead the battle side — every other state keeps
+/// vanilla roles, including detached-duty fights (the player's own business) and the
+/// player somehow leading the side (never strip the actual leader's command).
+/// </summary>
+[TestClass]
+public class BattleCommandPolicyTests
+{
+    [TestMethod]
+    public void EnlistedBattle_NotLeadingSide_Strips()
+        => Assert.IsTrue(BattleCommandPolicy.ShouldStripPlayerCommand(
+            EnlistmentState.EnlistedBattle, playerLeadsBattleSide: false));
+
+    [TestMethod]
+    public void EnlistedBattle_LeadingSide_DoesNotStrip()
+        => Assert.IsFalse(BattleCommandPolicy.ShouldStripPlayerCommand(
+            EnlistmentState.EnlistedBattle, playerLeadsBattleSide: true));
+
+    [TestMethod]
+    public void DetachedDutyBattle_DoesNotStrip()
+        => Assert.IsFalse(BattleCommandPolicy.ShouldStripPlayerCommand(
+            EnlistmentState.EnlistedDetachedOnDuty, playerLeadsBattleSide: false));
+
+    [TestMethod]
+    public void NotEnlisted_DoesNotStrip()
+        => Assert.IsFalse(BattleCommandPolicy.ShouldStripPlayerCommand(
+            EnlistmentState.NotEnlisted, playerLeadsBattleSide: false));
+
+    [TestMethod]
+    public void EnlistedAttached_DoesNotStrip()
+        => Assert.IsFalse(BattleCommandPolicy.ShouldStripPlayerCommand(
+            EnlistmentState.EnlistedAttached, playerLeadsBattleSide: false));
+}

--- a/TAOM.Tests/Features/Enlistment/EnlistmentBattleRoleBindingTests.cs
+++ b/TAOM.Tests/Features/Enlistment/EnlistmentBattleRoleBindingTests.cs
@@ -1,0 +1,53 @@
+using HarmonyLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TAOM.Tests.Migration;
+
+namespace TAOM.Tests.Features.Enlistment;
+
+/// <summary>
+/// Drift-guards for the #424 correction's engine bindings.
+/// <c>EnlistmentBattleRoleMissionBehavior</c> calls <c>Team.SetPlayerRole(bool, bool)</c> and
+/// reads <c>MapEvent.GetLeaderParty</c>/<c>PlayerSide</c>; a signature change would make the
+/// role correction silently no-op and re-expose the private-commands-the-army defect. These
+/// tests redden offline instead.
+/// </summary>
+[TestClass]
+public class EnlistmentBattleRoleBindingTests
+{
+    private static bool _gameLoaded;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) => _gameLoaded = GameAssemblies.EnsureLoaded();
+
+    [TestMethod]
+    [TestCategory("BindingVerification")]
+    public void Team_SetPlayerRole_SignatureMatchesInstalledEngine()
+    {
+        if (!_gameLoaded)
+            Assert.Inconclusive("Game assemblies not loaded: " + string.Join("; ", GameAssemblies.Diagnostics));
+
+        var team = AccessTools.TypeByName("TaleWorlds.MountAndBlade.Team");
+        Assert.IsNotNull(team, "TaleWorlds.MountAndBlade.Team not found in the installed engine.");
+
+        var method = AccessTools.Method(team, "SetPlayerRole", new[] { typeof(bool), typeof(bool) });
+        Assert.IsNotNull(method,
+            "Team.SetPlayerRole(bool, bool) missing — the #424 role correction would silently no-op.");
+        Assert.IsFalse(method.IsStatic, "Team.SetPlayerRole is expected to be an instance method.");
+    }
+
+    [TestMethod]
+    [TestCategory("BindingVerification")]
+    public void MapEvent_LeaderPartyAndPlayerSide_ResolveAgainstInstalledEngine()
+    {
+        if (!_gameLoaded)
+            Assert.Inconclusive("Game assemblies not loaded: " + string.Join("; ", GameAssemblies.Diagnostics));
+
+        var mapEvent = AccessTools.TypeByName("TaleWorlds.CampaignSystem.MapEvents.MapEvent");
+        Assert.IsNotNull(mapEvent, "MapEvent not found in the installed engine.");
+
+        Assert.IsNotNull(AccessTools.Method(mapEvent, "GetLeaderParty"),
+            "MapEvent.GetLeaderParty missing — the leads-the-side check would not compile against this engine.");
+        Assert.IsNotNull(AccessTools.Property(mapEvent, "PlayerSide"),
+            "MapEvent.PlayerSide missing — the leads-the-side check would not compile against this engine.");
+    }
+}


### PR DESCRIPTION
Addresses #424 — deliberately not "Fixes": the in-game F1–F8 observation the issue asks for is still owed, and the tester who does our field verification has a build with this exact question on their list.

## What this does

`EnlistmentBattleRoleMissionBehavior` (`MissionLogic`, registered unconditionally from SubModule, filters inside — same convention as `EnlistmentMeritMissionBehavior`) calls `Team.SetPlayerRole(false, false)` when the battle was entered as enlisted service (`EnlistedBattle`) and the player does not lead the battle side. `BattleCommandPolicy` is the pure decision table:

| State | Player leads side | Command stripped |
|---|---|---|
| `EnlistedBattle` | no | **yes** |
| `EnlistedBattle` | yes | no |
| `EnlistedDetachedOnDuty` | — | no (their duty, their fight) |
| anything else | — | no |

## Why option (a) and not the SAS rig

Per the issue's own warning: SAS's `GetCharacterSergeantScore` rig feeds `GetLeaderOfMapEvent` and mutates campaign-level battle leadership. This PR touches mission-side team roles only.

The issue flagged neither-general-nor-sergeant as untested engine ground with deployment/OOB as the named risk. Checked against the installed 1.4.7 DLLs before writing: `BattleInitializationModel.CanPlayerSideDeployWithOrderOfBattle`'s body reads no player-role flag, and `Team.SetPlayerRole(bool, bool)` itself just sets the two flags and re-walks formation ownership — so the correction at `AfterStart` (which runs after `AssignPlayerRoleInTeamMissionController.AfterStart`, since SubModule behaviors append after the mission's own list) does not disturb deployment selection.

## Ordering gate

The issue's ordering note — no mission-layer work before #406's in-game verification — is satisfied: #406 closed 2026-08-08 on the four field-verified battle joins.

## Tests

7/7 green locally (engine references resolved against the installed 1.4.7 binaries):
- `BattleCommandPolicyTests` — the decision table above
- `EnlistmentBattleRoleBindingTests` (`BindingVerification`) — pins `Team.SetPlayerRole(bool, bool)` and `MapEvent.GetLeaderParty`/`PlayerSide` so engine drift reddens offline instead of silently no-opping the correction

Not-tested: the F1–F8 in-game observation — that lands on #424 from the field tester, and if it shows something this approach can't explain, this PR should wait for it.
