### PR TITLE
fix(enlistment): a Rohan recruit draws Rohan gloves

### DIFF
--- a/Main/_Module/ModuleData/equipmentsets/taom_enlistment_equipment.xml
+++ b/Main/_Module/ModuleData/equipmentsets/taom_enlistment_equipment.xml
@@ -669,7 +669,12 @@
             <Equipment slot="Head" id="Item.cts_rohan_helmet4a" />
             <Equipment slot="Body" id="Item.rohan_militia_armour_c" />
             <Equipment slot="Leg" id="Item.roh_sol_bts" />
-            <Equipment slot="Gloves" id="Item.sk_gd_ano_gloves_a" />
+            <!-- cts_rohan_armguard1, not sk_gd_ano_gloves_a: the Gondor Anorien glove was a
+                 copy-paste stray. troops_rohan.xml uses cts_rohan_* gloves ~80:2 over sk_gd_*,
+                 and armguard1 is worn at militia tier (rohan_edoras_militia, level 11) — the
+                 right weight for a recruit. Reported in play 2026-08-08 ("the quartermaster
+                 gives me gondor gloves and I'm enlisted under Theoden"). -->
+            <Equipment slot="Gloves" id="Item.cts_rohan_armguard1" />
             <Equipment slot="Cape" id="Item.rohan_militia_pauldron_both" />
         </EquipmentSet>
     </EquipmentRoster>

--- a/TAOM.Tests/Features/Enlistment/EnlistmentEquipmentCultureTests.cs
+++ b/TAOM.Tests/Features/Enlistment/EnlistmentEquipmentCultureTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TAOM.Tests.Features.Enlistment;
+
+/// <summary>
+/// Guards the Rohan enlistment kits against Gondor item leakage (#375, reported in play
+/// 2026-08-08: "the quartermaster gives me gondor gloves and I'm enlisted under Theoden").
+/// Culture resolution was correct — the roster CONTENT carried a stray
+/// <c>sk_gd_ano_gloves_a</c> in <c>enlist_vlandia_recruit</c>.
+///
+/// Deliberately vlandia-only. Umbar's enlistment kits also carry <c>sk_gd_ano_*</c> items,
+/// and that is NOT a defect to guard against: troops_umbar.xml dresses Umbar troops in the
+/// same Anorien set as their primary kit (33 uses each of the four pieces — the most-used
+/// armour items in the file), so the enlisted player matching them is consistent, and
+/// plausibly deliberate Black-Numenorean styling. A blanket prefix-to-culture rule would
+/// redden on that intended data. If Umbar's dress is ever re-judged, change the troop tree
+/// first and this guard's scope second.
+/// </summary>
+[TestClass]
+public class EnlistmentEquipmentCultureTests
+{
+    private const string RosterRelPath = "Main/_Module/ModuleData/equipmentsets/taom_enlistment_equipment.xml";
+
+    [TestMethod]
+    public void VlandiaEnlistmentKits_ContainNoGondorItems()
+    {
+        var doc = XDocument.Load(FromRepoRoot(RosterRelPath));
+
+        var vlandiaRosters = doc.Descendants("EquipmentRoster")
+            .Where(r => ((string)r.Attribute("id") ?? "").StartsWith("enlist_vlandia_", StringComparison.Ordinal))
+            .ToList();
+        Assert.IsTrue(vlandiaRosters.Count >= 4,
+            "Expected the four vlandia rank rosters; the file layout changed and this guard needs re-aiming.");
+
+        var offenders = vlandiaRosters
+            .SelectMany(r => r.Descendants("Equipment")
+                .Select(e => new
+                {
+                    Roster = (string)r.Attribute("id"),
+                    Slot = (string)e.Attribute("slot"),
+                    Item = (string)e.Attribute("id") ?? string.Empty,
+                }))
+            .Where(x => x.Item.StartsWith("Item.sk_gd_", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.AreEqual(0, offenders.Count,
+            "Gondor (sk_gd_*) items in Rohan enlistment kits: " +
+            string.Join(", ", offenders.Select(o => $"{o.Roster}/{o.Slot}={o.Item}")));
+    }
+
+    private static string FromRepoRoot(string relPath)
+    {
+        var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+        while (dir != null)
+        {
+            // File.Exists too, not just Directory.Exists: in a git WORKTREE `.git` is a FILE
+            // holding a `gitdir:` pointer, not a directory (see f1bc6b39).
+            var gitPath = Path.Combine(dir.FullName, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+                return Path.Combine(dir.FullName, relPath.Replace('/', Path.DirectorySeparatorChar));
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("repo root (.git) not found from " + AppDomain.CurrentDomain.BaseDirectory);
+    }
+}


### PR DESCRIPTION
Addresses the Rohan half of the culture-kit finding on #375 ("the quartermaster gives me gondor gloves and I'm enlisted under Theoden", 2026-08-08).

## The fix

One data line: `enlist_vlandia_recruit` Gloves `sk_gd_ano_gloves_a` → `cts_rohan_armguard1`.

The replacement is chosen from the faction's own dress code rather than by name: `troops_rohan.xml` uses `cts_rohan_*` gloves ~80:2 over `sk_gd_*`, and `armguard1` is worn at militia tier (`rohan_edoras_militia`, level 11) — recruit-appropriate weight. (The 2 stray `sk_gd_ano_gloves_a` uses in the Rohan troop tree itself are on that same militia's variant set — same copy-paste family, left for a content pass since a troop-variant look may be deliberate.)

## A correction to my own #375 comment: Umbar is NOT fixed here, on purpose

My field-test comment called the Umbar rosters ("a veteran Corsair dressed as a Gondor soldier in four of five slots") a defect. **The troop data says otherwise**: `troops_umbar.xml` dresses Umbar troops in that same `sk_gd_ano_*` Anórien set as their **primary kit** — 33 uses each of the four pieces, the most-used armour items in the file. The enlisted player matching the troops around him is consistent, and plausibly deliberate Black-Númenórean styling. If that dress is ever re-judged it should start at the troop tree, not the enlistment roster — the guard test's doc comment records the evidence so nobody "fixes" Umbar from my earlier comment.

## Guard test

`EnlistmentEquipmentCultureTests` parses the roster XML and reddens on any `sk_gd_*` item in an `enlist_vlandia_*` roster. Deliberately vlandia-scoped for the reason above; uses the worktree-safe repo locator from `f1bc6b39`. 1/1 green locally.

Not-tested: in-game visual of the recruit kit — one quartermaster request covers it, and the test kit currently with the field testers makes that likely soon.
