### PR TITLE
fix(diagnostics): exit sampler stops at MapResumed

### DIFF
--- a/Main/Features/BattleLoadDiagnostics/BattleLoadDiagnosticsService.cs
+++ b/Main/Features/BattleLoadDiagnostics/BattleLoadDiagnosticsService.cs
@@ -392,6 +392,14 @@ public sealed class BattleLoadDiagnosticsService : IBattleLoadDiagnosticsService
 
     public void LogMapResumed(bool isSaving)
     {
+        // #425 — MapResumed is the end of the TEARDOWN the stall sampler exists to watch.
+        // Everything after it is player time: menus, conversations, loot screens (field-measured
+        // 123 s in a quartermaster conversation with three [ERROR] samples fired into it).
+        // Disarm the sampler here, unconditionally — same reasoning as CloseExitWindow's
+        // toggle-off note — while _exitWindowActive stays true so FirstMapTick still logs the
+        // time-to-playable tail for the phase record.
+        Interlocked.Exchange(ref _exitWindowOpenedUtcTicks, 0L);
+
         if (!IsExitPhaseLoggable()) return;
         Emit(BattleLoadPhase.MapResumed, $"isSaving={isSaving} {MemStats()}");
     }

--- a/Main/Features/BattleLoadDiagnostics/ExitStallSampler.cs
+++ b/Main/Features/BattleLoadDiagnostics/ExitStallSampler.cs
@@ -8,9 +8,13 @@ namespace TAOM.Features.BattleLoadDiagnostics;
 
 // Exit-stall stack sampler (#331 round 2). The ~107s tournament-exit stall froze the MAIN
 // thread inside Mission.EndMissionInternal, so — like BattleLoadStallWatchdog — only a
-// background thread can observe it. While the diagnostics exit window is open (opened by
-// LogExitBegin, closed by FirstMapTick/ResetLifecycle/MissionInitialize), this samples the
-// main thread's managed stack at +15s/+30s/+60s and logs the frames. Three samples of a
+// background thread can observe it. The sampler is armed by LogExitBegin and DISARMED at
+// MapResumed (#425): teardown is what it watches, and everything after MapResumed is player
+// time — menus, conversations, loot — field-measured at 123 s with three [ERROR] samples
+// fired into an ordinary quartermaster chat before the disarm existed. The logging window
+// itself stays open to FirstMapTick (or ResetLifecycle/MissionInitialize, and OnGameEnd for
+// the quit-to-load path where no map tick ever comes). While armed, this samples the main
+// thread's managed stack at +15s/+30s/+60s and logs the frames. Three samples of a
 // deterministic stall name the hot method (a loop shows identical top frames each time).
 // Independently disableable via the "Enable Exit Stall Sampler" MCM toggle (the only
 // diagnostics component that suspends the main thread).
@@ -20,7 +24,7 @@ namespace TAOM.Features.BattleLoadDiagnostics;
 // thread mid-GC and then allocating can deadlock the sampler before Resume — acceptable for
 // a dev-machine diagnostic on a 100%-reproducible stall (worst case: kill + retry). The
 // whole capture is try/catch'd with Resume in finally, and the sampler only ever runs while
-// the exit window is open (never during normal play).
+// a mission teardown is actually in progress.
 public sealed class ExitStallSampler : IDisposable
 {
     private const string Tag = "[ExitStall]";

--- a/Main/SubModule.cs
+++ b/Main/SubModule.cs
@@ -553,6 +553,24 @@ public class SubModule : MBSubModuleBase
         }
     }
 
+    public override void OnGameEnd(Game game)
+    {
+        base.OnGameEnd(game);
+
+        // #425 — the exit-stall window must die with the Game that opened it. A post-battle
+        // quit-to-load (or quit-to-menu) leaves the mission-exit window armed with no map tick
+        // ever coming, so ExitStallSampler kept firing Thread.Suspend stack captures INTO the
+        // next campaign's load (observed live: samples during MBObjectManager.LoadXML, the
+        // heaviest allocation phase in the process — the class's own documented suspend-mid-GC
+        // hazard). ResetLifecycle's window close is deliberately unconditional, same reasoning
+        // as the PlayerEncounter.Start site.
+        try
+        {
+            IoC.Resolve<Features.BattleLoadDiagnostics.IBattleLoadDiagnosticsService>()?.ResetLifecycle();
+        }
+        catch { /* diagnostic is best-effort, never break OnGameEnd */ }
+    }
+
     protected override void OnGameStart(Game game, IGameStarter gameStarterObject)
     {
         base.OnGameStart(game, gameStarterObject);

--- a/TAOM.Tests/Features/BattleLoadDiagnostics/ExitStallDisarmTests.cs
+++ b/TAOM.Tests/Features/BattleLoadDiagnostics/ExitStallDisarmTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using TAOM.Core.Logging;
+using TAOM.Features.BattleLoadDiagnostics;
+
+namespace TAOM.Tests.Features.BattleLoadDiagnostics;
+
+/// <summary>
+/// #425 — the stall sampler must disarm at MapResumed while the phase-logging window stays
+/// open to FirstMapTick. Field evidence for the split: MapResumed landed within ~1 s of
+/// ExitBegin on all 16 observed exits across two sessions, while the sampler kept firing
+/// [ERROR] Thread.Suspend captures up to 123 s later into ordinary menus, and — worst case —
+/// into the next campaign's XML load after a quit-to-load (no map tick ever comes, so
+/// FirstMapTick alone can never close that path; SubModule.OnGameEnd now does).
+/// </summary>
+[TestClass]
+public class ExitStallDisarmTests
+{
+    private IBattleLoadDiagnosticsSettingsProvider _settings;
+    private BattleLoadDiagnosticsService _sut;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _settings = Substitute.For<IBattleLoadDiagnosticsSettingsProvider>();
+        var formatter = Substitute.For<IEquipmentDumpFormatter>();
+        formatter.Format(Arg.Any<TAOM.Features.BattleLoadDiagnostics.Domain.EquipmentSnapshot>())
+            .Returns(new List<string>());
+        _settings.IsEnabled.Returns(true);
+        _sut = new BattleLoadDiagnosticsService(Substitute.For<IModLogger>(), _settings, formatter);
+    }
+
+    [TestMethod]
+    public void MapResumed_DisarmsSampler_WhileLoggingWindowStaysOpen()
+    {
+        _sut.LogExitBegin("m", "s", 1, 1);
+        Assert.AreNotEqual(0L, _sut.ExitWindowOpenedUtcTicks, "ExitBegin must arm the sampler.");
+
+        _sut.LogMapResumed(isSaving: false);
+
+        Assert.AreEqual(0L, _sut.ExitWindowOpenedUtcTicks,
+            "MapResumed must disarm the sampler — time after it is player time, not teardown.");
+        Assert.IsTrue(_sut.IsExitWindowActive,
+            "The phase-logging window must survive MapResumed so FirstMapTick still logs.");
+
+        _sut.LogFirstMapTick(isSaving: false);
+        Assert.IsFalse(_sut.IsExitWindowActive, "FirstMapTick closes the logging window.");
+    }
+
+    [TestMethod]
+    public void MapResumed_Disarm_IsUnconditional_WhenToggledOffMidWindow()
+    {
+        _sut.LogExitBegin("m", "s", 1, 1);
+        Assert.AreNotEqual(0L, _sut.ExitWindowOpenedUtcTicks);
+
+        // A toggle-off between ExitBegin and MapResumed must not latch the sampler armed —
+        // the same rule CloseExitWindow already documents for the logging window.
+        _settings.IsEnabled.Returns(false);
+        _sut.LogMapResumed(isSaving: false);
+
+        Assert.AreEqual(0L, _sut.ExitWindowOpenedUtcTicks,
+            "Disarm must run even while the master toggle is off, or a mid-window toggle-off " +
+            "leaves the sampler suspending the main thread indefinitely.");
+    }
+
+    [TestMethod]
+    public void ResetLifecycle_ClosesAnArmedWindow_TheQuitToLoadPath()
+    {
+        _sut.LogExitBegin("m", "s", 1, 1);
+        Assert.AreNotEqual(0L, _sut.ExitWindowOpenedUtcTicks);
+
+        // SubModule.OnGameEnd routes here when the Game that opened the window dies
+        // (quit-to-load / quit-to-menu). MapResumed and FirstMapTick never fire on that path.
+        _sut.ResetLifecycle();
+
+        Assert.AreEqual(0L, _sut.ExitWindowOpenedUtcTicks, "ResetLifecycle must disarm the sampler.");
+        Assert.IsFalse(_sut.IsExitWindowActive, "ResetLifecycle must close the logging window.");
+    }
+}


### PR DESCRIPTION
Fixes #425.

## The two arming failures, both field-measured

**Post-battle player time.** `MapResumed` landed within ~1 s of `ExitBegin` on all 16 observed exits across two sessions — but the sampler stays armed until `FirstMapTick`, which never comes while the player sits in menus. Result: three `[ERROR]` `Thread.Suspend` captures fired into an ordinary quartermaster conversation inside a 123 s window (evidence table in #425).

**Quit-to-load.** Neither `MapResumed` nor `FirstMapTick` fires when the player leaves a finished battle for a save load, so the sampler ran into the *next campaign's* initialization — the captured stack in #425 shows the suspend landing in `MBObjectManager.LoadXML` via `GameLoadingState.OnTick`, the heaviest allocation phase in the process, i.e. exactly the suspend-mid-GC hazard the sampler's own header documents.

## The fix

- `LogMapResumed` zeroes the sampler feed **unconditionally** (same toggle-off rule `CloseExitWindow` already documents), while `_exitWindowActive` stays true so `FirstMapTick` still records the time-to-playable tail in the phase log. Sampler-arm and logging-window are now distinct lifetimes.
- `SubModule.OnGameEnd` routes to `ResetLifecycle()` so the window dies with the Game that opened it — covers quit-to-load and quit-to-menu, where no map tick ever comes.
- The sampler header no longer claims the window is "closed by FirstMapTick/ResetLifecycle/MissionInitialize" alone. That list was true and incomplete — the reviewed-comment bug class this repo keeps finding.

**The genuine target is preserved**: a teardown that hangs *before* `MapResumed` — the ~107 s tournament-exit stall this sampler was built for (#331) — still gets all three samples, because the disarm sits at the phase boundary a real stall never reaches.

## Tests

76/76 green locally (`ExitStallDisarmTests` ×3 new + the full existing `BattleLoadDiagnosticsService` suite unbroken): disarm-at-MapResumed with the logging window surviving, disarm unconditional under mid-window toggle-off, and `ResetLifecycle` closing an armed window on the quit-to-load path.

Not-tested: a live quit-to-load pass with the sampler enabled — the field testers' next session covers it.
