### PR TITLE
fix(diagnostics): disarm at the Load Game click

### DIFF
--- a/Main/Features/BattleLoadDiagnostics/Hooks/SandBoxSaveHelper_TryLoadSave_DisarmPatch.cs
+++ b/Main/Features/BattleLoadDiagnostics/Hooks/SandBoxSaveHelper_TryLoadSave_DisarmPatch.cs
@@ -1,0 +1,43 @@
+using HarmonyLib;
+using SandBox;
+using TaleWorlds.SaveSystem;
+
+namespace TAOM.Features.BattleLoadDiagnostics.Hooks;
+
+// #425 follow-up (PR #429 review, HIGH): the quit-to-load disarm must run BEFORE the next
+// campaign's load work, and SubModule.OnGameEnd cannot guarantee that. Verified against the
+// installed 1.4.7 DLLs: Game.Destroy has exactly two callers —
+// Game::IGameStateManagerOwner.OnStateStackEmpty and MBInitialScreenBase.OnInitialize. The
+// second proves OnGameEnd fires on quit-to-MENU (the initial screen destroys the old Game);
+// neither sits on the early in-campaign load path, so on quit-to-LOAD the exit window could
+// stay armed into MBObjectManager.LoadXML — the suspend-mid-allocation hazard the captured
+// stack in #425 shows.
+//
+// SandBoxSaveHelper.TryLoadSave is the Load Game click itself — the same origin
+// SaveLoadDiagnostics stamps as LoadRequested — which precedes any teardown of the old Game
+// by construction. A prefix here closes the window earlier than either Destroy caller can.
+//
+// ResetLifecycle, not a bare disarm: its window close is deliberately unconditional (same
+// toggle-off rule as CloseExitWindow), and a load discards the mission the loadout cache
+// described, so the full lifecycle reset is the correct scope. Idempotent when no window is
+// open. SubModule.OnGameEnd keeps its ResetLifecycle call for the quit-to-menu path this
+// patch never sees.
+[HarmonyPatch(typeof(SandBoxSaveHelper), nameof(SandBoxSaveHelper.TryLoadSave))]
+[HarmonyPatchCategory("Patch43_BattleLoadDiagnostics")]
+public static class SandBoxSaveHelper_TryLoadSave_DisarmPatch
+{
+    private static IBattleLoadDiagnosticsService? _service;
+
+    public static void Initialize(IBattleLoadDiagnosticsService service) => _service = service;
+
+    [HarmonyPrefix]
+    public static void Prefix(SaveGameFileInfo saveInfo)
+    {
+        var svc = _service;
+        if (svc == null) return;
+        try { svc.ResetLifecycle(); }
+        catch { /* diagnostic only — never break a save load */ }
+
+        _ = saveInfo; // signature match with the engine method; identity is logged by SaveLoadDiagnostics' own patch
+    }
+}

--- a/Main/SubModule.cs
+++ b/Main/SubModule.cs
@@ -1270,6 +1270,10 @@ public class SubModule : MBSubModuleBase
         Features.BattleLoadDiagnostics.Hooks.MissionState_OnFinalize_ExitPhase_Patch.Initialize(battleLoadSvc);
         Features.BattleLoadDiagnostics.Hooks.MapState_OnActivate_ExitPhase_Patch.Initialize(battleLoadSvc);
         Features.BattleLoadDiagnostics.Hooks.MapState_OnTick_ExitPhase_Patch.Initialize(battleLoadSvc);
+        // #425 quit-to-load disarm: the Load Game click precedes any teardown of the old Game,
+        // which OnGameEnd cannot guarantee (Game.Destroy's two callers are OnStateStackEmpty and
+        // MBInitialScreenBase.OnInitialize — neither is on the early in-campaign load path).
+        Features.BattleLoadDiagnostics.Hooks.SandBoxSaveHelper_TryLoadSave_DisarmPatch.Initialize(battleLoadSvc);
         // Guarded like Patch60/61/62: this category binds several engine targets by string (two of
         // them private), so an engine bump can throw here. A DIAGNOSTICS category must never take
         // startup down with it — losing the stamps is survivable, losing the game is not.

--- a/TAOM.Tests/Features/BattleLoadDiagnostics/ExitStallDisarmTests.cs
+++ b/TAOM.Tests/Features/BattleLoadDiagnostics/ExitStallDisarmTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using TAOM.Core.Logging;
@@ -76,5 +78,58 @@ public class ExitStallDisarmTests
 
         Assert.AreEqual(0L, _sut.ExitWindowOpenedUtcTicks, "ResetLifecycle must disarm the sampler.");
         Assert.IsFalse(_sut.IsExitWindowActive, "ResetLifecycle must close the logging window.");
+    }
+
+    [TestMethod]
+    public void PreMapResumedStall_KeepsTheSamplerArmed()
+    {
+        // The preservation half of #425 (PR #429 review, LOW): the ~107s tournament-exit
+        // stall (#331) hangs BEFORE MapResumed, and it must still get all three samples.
+        // A later edit that disarms earlier than MapResumed silently deletes the feature;
+        // this pins the semantics the disarm boundary was chosen to preserve.
+        _sut.LogExitBegin("m", "s", 1, 1);
+        _sut.LogExitTeardownBegin();
+        _sut.LogExitStateFinalizeBegin();
+        _sut.LogExitResourceClearBegin(forceClearGpuResources: false);
+
+        Assert.AreNotEqual(0L, _sut.ExitWindowOpenedUtcTicks,
+            "No exit phase before MapResumed may disarm the sampler — a real teardown stall " +
+            "must remain sampleable through the entire teardown sequence.");
+    }
+
+    [TestMethod]
+    public void DisarmWiring_IsPresentInBothClosers()
+    {
+        // PR #429 review, LOW: the service tests stay green if the wiring is deleted. Pin the
+        // two closers at the source level: SubModule.OnGameEnd (quit-to-menu; Game.Destroy's
+        // only menu-path caller is MBInitialScreenBase.OnInitialize) and the TryLoadSave
+        // prefix (quit-to-load; precedes any teardown of the old Game by construction).
+        var subModule = File.ReadAllText(FromRepoRoot("Main/SubModule.cs"));
+        StringAssert.Contains(subModule, "SandBoxSaveHelper_TryLoadSave_DisarmPatch.Initialize",
+            "The quit-to-load disarm patch is no longer wired from SubModule — the sampler can " +
+            "again ride into the next campaign's LoadXML (#425 HIGH).");
+        StringAssert.Contains(subModule, "public override void OnGameEnd",
+            "SubModule.OnGameEnd is gone — the quit-to-menu path no longer closes the exit window.");
+
+        var patch = File.ReadAllText(FromRepoRoot(
+            "Main/Features/BattleLoadDiagnostics/Hooks/SandBoxSaveHelper_TryLoadSave_DisarmPatch.cs"));
+        StringAssert.Contains(patch, "ResetLifecycle",
+            "The TryLoadSave prefix no longer resets the lifecycle — the disarm is a no-op.");
+    }
+
+    private static string FromRepoRoot(string relPath)
+    {
+        var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+        while (dir != null)
+        {
+            // File.Exists too, not just Directory.Exists: in a git WORKTREE `.git` is a FILE
+            // holding a `gitdir:` pointer, not a directory (see f1bc6b39).
+            var gitPath = Path.Combine(dir.FullName, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+                return Path.Combine(dir.FullName, relPath.Replace('/', Path.DirectorySeparatorChar));
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("repo root (.git) not found from " + AppDomain.CurrentDomain.BaseDirectory);
     }
 }


### PR DESCRIPTION
Answers the #429 review's HIGH and LOW (the two doc MEDs were covered by `3b0e0831`; the evidence MED is answered below and in a review reply).

## The HIGH, verified — the concern is correct

Cecil scan of all four campaign assemblies: **`Game.Destroy` has exactly two callers.**

| Caller | Path it covers |
|---|---|
| `Game::IGameStateManagerOwner.OnStateStackEmpty` | the cited chain |
| `MBInitialScreenBase.OnInitialize` | **quit-to-menu** — the initial screen destroys the old Game, so `OnGameEnd` provably fires there |

Neither sits on the early in-campaign load path, so on quit-to-**load** the `OnGameEnd` disarm cannot be guaranteed to beat `MBObjectManager.LoadXML` — exactly the review's concern.

## The fix

A prefix on `SandBoxSaveHelper.TryLoadSave` — the Load Game click itself, the same origin SaveLoadDiagnostics stamps as `LoadRequested` — which precedes any teardown of the old Game **by construction**, ending the ordering question rather than answering it. `OnGameEnd` stays for the quit-to-menu path the caller scan proves it owns. `ResetLifecycle` (not a bare disarm) because a load discards the mission the loadout cache described, and its window close is deliberately unconditional per the existing toggle-off rule.

## The evidence MED, resolved

The PR body's "neither MapResumed nor FirstMapTick fires" was wrong as stated — the review is right that the cited log shows both at 03:21:31. Those two lines belong to the **next campaign's** `MapState.OnActivate` reaching a still-open window (the hook is game-agnostic): the disarm exists on that path but lands ~2 minutes after `LoadXML`, i.e. the review's disarm-too-late finding restated, not a counterexample. The samples at +15/+31/+61s all predate it.

## The LOW — preservation pinned

- `PreMapResumedStall_KeepsTheSamplerArmed`: no exit phase before `MapResumed` may disarm — the ~107s tournament stall (#331) hangs exactly there and must keep all three samples.
- `DisarmWiring_IsPresentInBothClosers`: source-level pin on the `OnGameEnd` block, the new patch wiring, and the patch's `ResetLifecycle` call — deleting any of them now reddens instead of passing.

5/5 green locally. Not-tested: a live quit-to-load with the sampler enabled — field testers' next session.
