### PR TITLE
feat(enlistment): the soldier stands in the line

### DIFF
--- a/Main/Features/Enlistment/BattleFormationPolicy.cs
+++ b/Main/Features/Enlistment/BattleFormationPolicy.cs
@@ -1,0 +1,29 @@
+using TaleWorlds.Core;
+using TAOM.Features.Enlistment.Content.Domain;
+
+namespace TAOM.Features.Enlistment;
+
+/// <summary>
+/// Maps the enlisted soldier's <see cref="ServiceAssignment"/> to the battlefield formation
+/// they belong in (#441). Pure table so the mapping is testable without a mission.
+///
+/// Support is deliberately unmapped: the rear-echelon fantasy has no line to stand in, and
+/// forcing a Steward-track soldier into the shield wall would punish the assignment choice.
+/// Gating (EnlistedBattle + not leading the side) is shared with the #424 role strip via
+/// <see cref="BattleCommandPolicy.ShouldStripPlayerCommand"/> — the two corrections are the
+/// two halves of the same engine branch (BehaviorComponent v1.4.7 :105: neither-role AND
+/// IsPlayerTroopInFormation), so they must gate identically or the fantasy tears in half.
+/// </summary>
+public static class BattleFormationPolicy
+{
+    public static FormationClass? TargetFormationFor(ServiceAssignment assignment)
+    {
+        switch (assignment)
+        {
+            case ServiceAssignment.Infantry: return FormationClass.Infantry;
+            case ServiceAssignment.Archer: return FormationClass.Ranged;
+            case ServiceAssignment.Cavalry: return FormationClass.Cavalry;
+            default: return null;
+        }
+    }
+}

--- a/Main/Features/Enlistment/Hooks/EnlistmentBattleFormationMissionBehavior.cs
+++ b/Main/Features/Enlistment/Hooks/EnlistmentBattleFormationMissionBehavior.cs
@@ -1,0 +1,85 @@
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+using TAOM.Core.Logging;
+using TAOM.Features.Enlistment.Content;
+
+namespace TAOM.Features.Enlistment.Hooks;
+
+/// <summary>
+/// Puts the enlisted soldier IN a formation (#441) — the second half of the engine branch the
+/// #424 role strip made reachable. BehaviorComponent (v1.4.7, :105) runs its
+/// "player is a soldier inside a formation receiving orders" path only when the team has
+/// neither player role AND <c>Formation.IsPlayerTroopInFormation</c> is true; that flag is set
+/// by <c>Formation.AddUnit</c> when the added agent <c>IsPlayerTroop</c> (verified in the
+/// decompile), so plain <c>agent.Formation =</c> assignment completes it — the
+/// <c>ElephantMissionBehavior</c> idiom.
+///
+/// <c>: MissionLogic</c> — NEVER MissionBehavior (BehaviorTreeMissionLogic regression rule).
+/// Registered UNCONDITIONALLY from SubModule; all filtering happens inside.
+/// <c>OnAgentBuild</c> rather than AfterStart because the player agent does not exist yet at
+/// AfterStart on the enlisted join path; <c>agent.IsPlayerTroop</c> is roster-derived and
+/// already set at build time, and it is the exact flag AddUnit consults.
+///
+/// Repositioning is conservative: teleport to <c>Formation.OrderGroundPosition</c> only when
+/// the order position is valid AND the formation already has units — an empty or orderless
+/// formation keeps vanilla spawn placement and the player walks. A Cavalry-assigned soldier
+/// without a mount still joins the cavalry formation; placement follows the assignment the
+/// player chose, not their current horse.
+/// </summary>
+public class EnlistmentBattleFormationMissionBehavior : MissionLogic
+{
+    private readonly IEnlistmentStateQuery _query;
+    private readonly IEnlistmentContentStore _contentStore;
+    private readonly IModLogger _logger;
+
+    private bool _applied;
+
+    public EnlistmentBattleFormationMissionBehavior(
+        IEnlistmentStateQuery query,
+        IEnlistmentContentStore contentStore,
+        IModLogger logger)
+    {
+        _query = query;
+        _contentStore = contentStore;
+        _logger = logger;
+    }
+
+    public override void OnAgentBuild(Agent agent, Banner banner)
+    {
+        if (_applied || agent == null || !agent.IsPlayerTroop || Campaign.Current == null)
+            return;
+
+        var mapEvent = MobileParty.MainParty?.MapEvent;
+        if (mapEvent == null)
+            return;
+
+        var playerLeads = mapEvent.GetLeaderParty(mapEvent.PlayerSide) == PartyBase.MainParty;
+        if (!BattleCommandPolicy.ShouldStripPlayerCommand(_query.State, playerLeads))
+            return;
+
+        var targetClass = BattleFormationPolicy.TargetFormationFor(_contentStore.Record.Assignment);
+        if (targetClass == null)
+            return;
+
+        var team = agent.Team ?? Mission?.PlayerTeam;
+        if (team == null)
+            return;
+
+        var formation = team.GetFormation(targetClass.Value);
+        if (formation == null)
+            return;
+
+        var hadUnits = formation.CountOfUnits > 0;
+        agent.Formation = formation;
+        _applied = true;
+
+        if (hadUnits && formation.OrderPositionIsValid)
+            agent.TeleportToPosition(formation.OrderGroundPosition);
+
+        _logger?.LogInfo(
+            $"[Enlistment] soldier placed in the {targetClass.Value} formation" +
+            $"{(hadUnits && formation.OrderPositionIsValid ? " at its position" : " (no line to join yet — walking)")} (#441)");
+    }
+}

--- a/Main/SubModule.cs
+++ b/Main/SubModule.cs
@@ -1426,6 +1426,13 @@ public class SubModule : MBSubModuleBase
         AddTaomBehavior(new Features.Enlistment.Hooks.EnlistmentBattleRoleMissionBehavior(
             IoC.Resolve<Features.Enlistment.IEnlistmentStateQuery>(),
             IoC.Resolve<IModLogger>()));
+        // The second half of the same engine branch (#441): the role strip above delivers
+        // neither-role; this puts the soldier IN a formation so IsPlayerTroopInFormation
+        // completes BehaviorComponent's soldier path. Same gate, all filtering inside.
+        AddTaomBehavior(new Features.Enlistment.Hooks.EnlistmentBattleFormationMissionBehavior(
+            IoC.Resolve<Features.Enlistment.IEnlistmentStateQuery>(),
+            IoC.Resolve<Features.Enlistment.Content.IEnlistmentContentStore>(),
+            IoC.Resolve<IModLogger>()));
         // Registered unconditionally; self-filters internally on Campaign.Current and co-op authority.
         AddTaomBehavior(new Features.FieldCommission.Hooks.FieldCommissionMissionLogic());
         // Added unconditionally per TAOM convention; gates internally on

--- a/TAOM.Tests/Features/Enlistment/BattleFormationPolicyTests.cs
+++ b/TAOM.Tests/Features/Enlistment/BattleFormationPolicyTests.cs
@@ -1,0 +1,63 @@
+using HarmonyLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TaleWorlds.Core;
+using TAOM.Features.Enlistment;
+using TAOM.Features.Enlistment.Content.Domain;
+using TAOM.Tests.Migration;
+
+namespace TAOM.Tests.Features.Enlistment;
+
+/// <summary>
+/// #441 — the assignment-to-formation table, and the engine bindings the placement rides on.
+/// Support maps to null ON PURPOSE (rear-echelon fantasy keeps vanilla placement); a mapping
+/// added for it later should be a deliberate design change that reddens this table first.
+/// </summary>
+[TestClass]
+public class BattleFormationPolicyTests
+{
+    [TestMethod]
+    public void Infantry_MapsToInfantry()
+        => Assert.AreEqual(FormationClass.Infantry, BattleFormationPolicy.TargetFormationFor(ServiceAssignment.Infantry));
+
+    [TestMethod]
+    public void Archer_MapsToRanged()
+        => Assert.AreEqual(FormationClass.Ranged, BattleFormationPolicy.TargetFormationFor(ServiceAssignment.Archer));
+
+    [TestMethod]
+    public void Cavalry_MapsToCavalry()
+        => Assert.AreEqual(FormationClass.Cavalry, BattleFormationPolicy.TargetFormationFor(ServiceAssignment.Cavalry));
+
+    [TestMethod]
+    public void Support_IsDeliberatelyUnmapped()
+        => Assert.IsNull(BattleFormationPolicy.TargetFormationFor(ServiceAssignment.Support));
+
+    private static bool _gameLoaded;
+
+    [ClassInitialize]
+    public static void Init(TestContext _) => _gameLoaded = GameAssemblies.EnsureLoaded();
+
+    [TestMethod]
+    [TestCategory("BindingVerification")]
+    public void FormationPlacement_EngineBindings_ResolveAgainstInstalledEngine()
+    {
+        if (!_gameLoaded)
+            Assert.Inconclusive("Game assemblies not loaded: " + string.Join("; ", GameAssemblies.Diagnostics));
+
+        var agent = AccessTools.TypeByName("TaleWorlds.MountAndBlade.Agent");
+        Assert.IsNotNull(AccessTools.PropertySetter(agent, "Formation"),
+            "Agent.Formation setter missing — placement would not compile against this engine.");
+        Assert.IsNotNull(AccessTools.Method(agent, "TeleportToPosition"),
+            "Agent.TeleportToPosition missing — the reposition would silently not exist.");
+        Assert.IsNotNull(AccessTools.PropertyGetter(agent, "IsPlayerTroop"),
+            "Agent.IsPlayerTroop missing — the build-time player check would fail.");
+
+        var formation = AccessTools.TypeByName("TaleWorlds.MountAndBlade.Formation");
+        Assert.IsNotNull(AccessTools.PropertyGetter(formation, "IsPlayerTroopInFormation"),
+            "Formation.IsPlayerTroopInFormation missing — the engine soldier branch this feature " +
+            "completes (BehaviorComponent v1.4.7 :105) has moved.");
+        Assert.IsNotNull(AccessTools.PropertyGetter(formation, "OrderGroundPosition"),
+            "Formation.OrderGroundPosition missing — the reposition target has moved.");
+        Assert.IsNotNull(AccessTools.PropertyGetter(formation, "OrderPositionIsValid"),
+            "Formation.OrderPositionIsValid missing — the reposition guard has moved.");
+    }
+}


### PR DESCRIPTION
Fixes #441. The second half of the engine branch #426 opened.

## What it does

At main-agent build in an enlisted battle (same gate as the #424 role strip — `EnlistedBattle`, not leading the side), the player agent is assigned to the formation matching their `ServiceAssignment` and repositioned to it:

| Assignment | Formation |
|---|---|
| Infantry | Infantry |
| Archer | Ranged |
| Cavalry | Cavalry |
| Support | **unmapped — vanilla placement, on purpose** (rear-echelon fantasy; a mapping added later should redden the policy table first) |

## Why this completes #426 rather than adding to it

`BehaviorComponent` (v1.4.7, `:105`) gates the *player-is-a-soldier-receiving-orders* path on **both** `!IsPlayerGeneral && !IsPlayerSergeant` (delivered by #426) **and** `Formation.IsPlayerTroopInFormation` (delivered by nothing, until now). The flag is set by `Formation.AddUnit` when the added agent `IsPlayerTroop` — verified in the decompile — so plain `agent.Formation =` assignment completes it. That's the existing `ElephantMissionBehavior:98-101` idiom; the gate is shared verbatim via `BattleCommandPolicy.ShouldStripPlayerCommand` so the two halves can never gate apart.

`OnAgentBuild` rather than `AfterStart` because the player agent does not exist yet at `AfterStart` on the enlisted join path; `IsPlayerTroop` is roster-derived and set by build time, and it is the exact flag `AddUnit` consults.

## Conservative repositioning

Teleport to `Formation.OrderGroundPosition` only when `OrderPositionIsValid` **and** the formation already has units; an empty or orderless formation keeps vanilla spawn placement and the player walks. A Cavalry-assigned soldier without a mount still joins the cavalry formation — placement follows the chosen assignment, not the current horse.

## A side effect worth naming

`EnlistmentMeritMissionBehavior`'s cohesion sampling reads `Formation?.Captain` — which has been null for the entire life of the feature. The merit dimension becomes measurable for the first time with this change; merit distributions may shift and that is the instrument starting to work, not a regression.

## Tests

5/5 green: the four-row policy table (including Support-is-null as a pinned design decision) plus a `BindingVerification` pin on all six engine members the placement rides on.

Not-tested (field testers' next session): in-game placement and squad identity, the reposition on join, Support unchanged, and first-ever cohesion merit readings.
